### PR TITLE
feat: add ci workflows

### DIFF
--- a/.github/workflows/dev-jan-api-gateway.yml
+++ b/.github/workflows/dev-jan-api-gateway.yml
@@ -1,0 +1,28 @@
+name: CI - jan-api-gateway
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - "apps/jan-api-gateway/**"
+      - .github/workflows/dev-jan-api-gateway
+      - .github/workflows/template-docker.yml
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - "apps/jan-api-gateway/**"
+      - .github/workflows/dev-jan-api-gateway
+      - .github/workflows/template-docker.yml
+
+jobs:
+  build-docker-x64:
+    uses: ./.github/workflows/template-docker.yml
+    secrets: inherit
+    with:
+      runs-on: ubuntu-24-04-docker
+      docker-file: apps/jan-api-gateway/Dockerfile
+      context: apps/jan-api-gateway
+      registry-url: registry.menlo.ai
+      tags: registry.menlo.ai/jan-server/jan-api-gateway:dev-${{ github.sha }}
+      is_push: ${{ github.event_name == 'push' }}

--- a/.github/workflows/dev-jan-inference-model.yml
+++ b/.github/workflows/dev-jan-inference-model.yml
@@ -1,0 +1,29 @@
+name: CI - jan-inference-model
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - "apps/jan-inference-model/**"
+      - .github/workflows/dev-jan-inference-model
+      - .github/workflows/template-docker.yml
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - "apps/jan-inference-model/**"
+      - .github/workflows/dev-jan-inference-model
+      - .github/workflows/template-docker.yml
+
+jobs:
+  build-docker-x64:
+    uses: ./.github/workflows/template-docker.yml
+    secrets: inherit
+    with:
+      runs-on: ubuntu-24-04-docker
+      docker-file: apps/jan-inference-model/Dockerfile
+      context: apps/jan-inference-model
+      registry-url: registry.menlo.ai
+      tags: registry.menlo.ai/jan-server/jan-inference-model:dev-${{ github.sha }}
+      is_push: ${{ github.event_name == 'push' }}

--- a/.github/workflows/template-docker.yml
+++ b/.github/workflows/template-docker.yml
@@ -1,0 +1,94 @@
+name: build-docker-x64
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        required: false
+        type: string
+        default: "ubuntu-latest"
+        description: "The runner to use for this job"
+      docker-file:
+        required: true
+        type: string
+        default: "./Dockerfile"
+        description: "The docker file to use for this job"
+      context:
+        required: true
+        type: string
+        default: "."
+        description: "The context to use for this job"
+      registry-url:
+        required: false
+        type: string
+        default: "docker.io"
+        description: "The URL of the docker registry to use"
+      is_push:
+        required: false
+        type: boolean
+        default: true
+        description: "Whether to push the docker image"
+      build-args:
+        required: false
+        type: string
+        default: ""
+        description: "The build args to use for docker build"
+      tags:
+        required: false
+        type: string
+        default: "menloltd/cortex:latest"
+        description: "The tags to use for docker build and push"
+      need_build_time_env_file:
+        required: false
+        type: boolean
+        default: false
+        description: "Whether to use the build-time environment file"
+      dot_env_source_file:
+        required: false
+        type: string
+        default: ".env"
+        description: "The .env file to use for this job"
+      dot_env_destination_file:
+        required: false
+        type: string
+        default: ".env"
+        description: "The .env file to use for this job"
+
+jobs:
+  build-docker-x64:
+    runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: write
+    steps:
+      - name: Getting the repo
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.registry-url }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Set .env file for build-time environment
+        if: ${{ inputs.need_build_time_env_file }}
+        continue-on-error: true
+        run: |
+          mv ${{ inputs.dot_env_source_file }} ${{ inputs.dot_env_destination_file }}
+          cat ${{ inputs.dot_env_destination_file }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.docker-file }}
+          push: ${{ inputs.is_push }}
+          tags: ${{ inputs.tags }}
+          build-args: ${{ inputs.build-args }}

--- a/apps/jan-api-gateway/Dockerfile
+++ b/apps/jan-api-gateway/Dockerfile
@@ -1,10 +1,11 @@
 FROM golang:1.24.6-alpine AS builder
 WORKDIR /app
 
-COPY application/go.mod application/go.sum ./
+COPY application/go.mod ./
 RUN go mod download
 
 COPY application/. .
+RUN go mod tidy
 RUN go build -o /jan-api-gateway -ldflags="-s -w" ./cmd/server
 
 FROM alpine:latest


### PR DESCRIPTION
This pull request introduces new CI workflows and refactors Docker build automation for the `jan-api-gateway` and `jan-inference-model` applications. The main focus is on standardizing Docker build and push processes using a reusable workflow template and updating the Dockerfile for better dependency management.

**CI/CD Workflow Automation**

* Added `.github/workflows/dev-jan-api-gateway.yml` and `.github/workflows/dev-jan-inference-model.yml` to automate Docker builds and pushes for each app on changes to the `dev` branch, using a shared workflow template for consistency. [[1]](diffhunk://#diff-53ac7e3de148107abd0eae9cd61caaafca5d82e7440596f353fad2fad529f5d0R1-R28) [[2]](diffhunk://#diff-760e66f6d1e510b458fb4e4cbab152e523ef902ba7aea2185412a9735e272799R1-R29)
* Introduced `.github/workflows/template-docker.yml`, a reusable workflow that standardizes Docker build and push steps across projects, supporting custom runner, build args, tags, and environment file handling.

**Dockerfile Improvements**

* Updated `apps/jan-api-gateway/Dockerfile` to run `go mod tidy` after copying `go.mod` for improved dependency management and removed the unnecessary copy of `go.sum`.