### PR TITLE
chore: update jan inference model Dockerfile cmd

### DIFF
--- a/apps/jan-inference-model/Dockerfile
+++ b/apps/jan-inference-model/Dockerfile
@@ -6,4 +6,4 @@ RUN pip install --no-cache-dir huggingface_hub \
 
 EXPOSE 8101
 
-CMD ["--model", "Qwen/Qwen3-4B", "--host", "0.0.0.0", "--port", "8101"]
+CMD ["--model", "Qwen/Qwen3-4B", "--host", "0.0.0.0", "--port", "8101", "--gpu-memory-utilization", "0.65", "--enforce-eager", "--max_model_len", "32768"]


### PR DESCRIPTION
This pull request updates the container startup command in the `apps/jan-inference-model/Dockerfile` to enhance model serving performance and resource management. The new command introduces several runtime options to better control memory usage, execution mode, and model input size.

Model serving configuration improvements:

* Added `--gpu-memory-utilization 0.65` to limit GPU memory usage to 65%, helping prevent out-of-memory errors.
* Enabled `--enforce-eager` to force eager execution mode, which can simplify debugging and improve compatibility.
* Set `--max_model_len 32768` to increase the maximum allowed model input length, supporting larger prompts or documents.