### PR TITLE
chore: add ci prod

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,0 +1,32 @@
+name: CI - jan-server
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build-docker-x64:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - docker-file: apps/jan-inference-model/Dockerfile
+            context: apps/jan-inference-model
+            registry-url: registry.menlo.ai
+            tags: registry.menlo.ai/jan-server/jan-inference-model:${{ github.ref_name }}
+            is_push: true
+          - docker-file: apps/jan-api-gateway/Dockerfile
+            context: apps/jan-api-gateway
+            registry-url: registry.menlo.ai
+            tags: registry.menlo.ai/jan-server/jan-api-gateway:${{ github.ref_name }}
+            is_push: true
+    uses: ./.github/workflows/template-docker.yml
+    secrets: inherit
+    with:
+      runs-on: ubuntu-24-04-docker
+      docker-file: ${{ matrix.docker-file }}
+      context: ${{ matrix.context }}
+      registry-url: ${{ matrix.registry-url }}
+      tags: ${{ matrix.tags }}
+      is_push: ${{ matrix.is_push }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and pushing Docker images for production releases. The workflow is triggered on version tag pushes and builds Docker images for both the `jan-inference-model` and `jan-api-gateway` applications.

**CI/CD automation:**

* Added a new workflow file `.github/workflows/prod.yml` that triggers on version tag pushes and builds Docker images for `jan-inference-model` and `jan-api-gateway`, pushing them to the `registry.menlo.ai` container registry.
* Utilizes a matrix strategy to build and push both applications in parallel, and delegates the build process to a reusable workflow (`template-docker.yml`).