### PR TITLE
Chore: enable auto instrument

### DIFF
--- a/apps/jan-api-gateway/Dockerfile
+++ b/apps/jan-api-gateway/Dockerfile
@@ -8,7 +8,7 @@ ARG VERSION_TAG=dev
 COPY application/. .
 RUN go mod tidy
 RUN go build -o /jan-api-gateway \
-    -ldflags="-s -w -X 'menlo.ai/jan-api-gateway/config.Version=${VERSION_TAG}'" \
+    -ldflags="-s -X 'menlo.ai/jan-api-gateway/config.Version=${VERSION_TAG}'" \
     ./cmd/server
 
 FROM alpine:latest


### PR DESCRIPTION
This pull request makes a minor update to the Docker build process for `jan-api-gateway`, specifically adjusting the linker flags used during the Go build step. The change removes the `-w` flag from the `-ldflags` option, which previously stripped debug information from the binary.

- Dockerfile update:
  * Removed the `-w` linker flag from the Go build command in `apps/jan-api-gateway/Dockerfile`, so debug information is now retained in the built binary.