### PR TITLE
chore: change go build flag

### DIFF
--- a/apps/jan-api-gateway/Dockerfile
+++ b/apps/jan-api-gateway/Dockerfile
@@ -8,7 +8,7 @@ ARG VERSION_TAG=dev
 COPY application/. .
 RUN go mod tidy
 RUN go build -o /jan-api-gateway \
-    -ldflags="-s -X 'menlo.ai/jan-api-gateway/config.Version=${VERSION_TAG}'" \
+    -ldflags="all=-N -l -X 'menlo.ai/jan-api-gateway/config.Version=${VERSION_TAG}'" \
     ./cmd/server
 
 FROM alpine:latest


### PR DESCRIPTION
This pull request makes a small adjustment to the build process in the `apps/jan-api-gateway/Dockerfile` by modifying the linker flags used during the Go build. This change is likely intended to facilitate debugging or alter build optimizations. 

- Updated the `go build` command to include the `-N -l` flags (via `all=-N -l`) in the `-ldflags` option, which disables optimizations and inlining for easier debugging.