### PR TITLE
chore: change go build flag

### DIFF
--- a/apps/jan-api-gateway/Dockerfile
+++ b/apps/jan-api-gateway/Dockerfile
@@ -8,7 +8,8 @@ ARG VERSION_TAG=dev
 COPY application/. .
 RUN go mod tidy
 RUN go build -o /jan-api-gateway \
-    -ldflags="all=-N -l -X 'menlo.ai/jan-api-gateway/config.Version=${VERSION_TAG}'" \
+    -gcflags="all=-N -l" \
+    -ldflags="-X menlo.ai/jan-api-gateway/config.Version=${VERSION_TAG}" \
     ./cmd/server
 
 FROM alpine:latest


### PR DESCRIPTION
This pull request makes a minor adjustment to the build process in the `apps/jan-api-gateway/Dockerfile`, specifically refining the flags used for building the Go binary. The change clarifies the use of compiler and linker flags for improved build clarity and maintainability.