### PR TITLE
chore: allow grafana beyla auto-instrument

### DIFF
--- a/apps/jan-api-gateway/Dockerfile
+++ b/apps/jan-api-gateway/Dockerfile
@@ -1,16 +1,20 @@
 FROM golang:1.24.6-alpine AS builder
 WORKDIR /app
 
+RUN apk add --no-cache build-base
+
 COPY application/go.mod ./
 RUN go mod download
 
 ARG VERSION_TAG=dev
 COPY application/. .
 RUN go mod tidy
-RUN go build -o /jan-api-gateway \
-    -gcflags="all=-N -l" \
-    -ldflags="-X menlo.ai/jan-api-gateway/config.Version=${VERSION_TAG}" \
-    ./cmd/server
+
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
+    go build -o /jan-api-gateway \
+      -gcflags="all=-N -l" \
+      -ldflags="-linkmode=external -X menlo.ai/jan-api-gateway/config.Version=${VERSION_TAG}" \
+      ./cmd/server
 
 FROM alpine:latest
 WORKDIR /root/


### PR DESCRIPTION
This pull request updates the `Dockerfile` for `apps/jan-api-gateway` to improve the build process and enable CGO support for the Go binary. The most important changes are:

**Build environment and dependencies:**

* Added installation of the `build-base` package to provide necessary system libraries for CGO-enabled builds.

**Go build configuration:**

* Enabled CGO by setting `CGO_ENABLED=1` and specified the target OS and architecture (`GOOS=linux`, `GOARCH=amd64`) to ensure compatibility and external linking.
* Updated the `go build` command to use `-ldflags="-linkmode=external"` for external linking, which is required when using CGO, and retained the version injection for the build.