### PR TITLE
Chore: cherry pick from dev

### DIFF
--- a/apps/jan-api-gateway/Dockerfile
+++ b/apps/jan-api-gateway/Dockerfile
@@ -1,16 +1,20 @@
 FROM golang:1.24.6-alpine AS builder
 WORKDIR /app
 
+RUN apk add --no-cache build-base
+
 COPY application/go.mod ./
 RUN go mod download
 
 ARG VERSION_TAG=dev
 COPY application/. .
 RUN go mod tidy
-RUN go build -o /jan-api-gateway \
-    -gcflags="all=-N -l" \
-    -ldflags="-X menlo.ai/jan-api-gateway/config.Version=${VERSION_TAG}" \
-    ./cmd/server
+
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
+    go build -o /jan-api-gateway \
+      -gcflags="all=-N -l" \
+      -ldflags="-linkmode=external -X menlo.ai/jan-api-gateway/config.Version=${VERSION_TAG}" \
+      ./cmd/server
 
 FROM alpine:latest
 WORKDIR /root/


### PR DESCRIPTION
This pull request updates the `Dockerfile` for `apps/jan-api-gateway` to improve the build process, mainly by enabling CGO and external linking, and preparing the image for debugging or native dependencies.

Build process improvements:

* Added the `build-base` package to the build stage to provide necessary system libraries and tools for CGO builds.
* Enabled CGO and set build flags for native Linux AMD64 builds, including `-gcflags="all=-N -l"` for easier debugging and `-ldflags="-linkmode=external"` for external linking.
* Updated the build command to ensure the version tag is set using the correct linker flag syntax.