### PR TITLE
chore: expose pprof endpoint

### DIFF
--- a/.github/workflows/dev-jan-api-gateway.yml
+++ b/.github/workflows/dev-jan-api-gateway.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - dev
+      - main
     paths:
       - "apps/jan-api-gateway/**"
       - .github/workflows/dev-jan-api-gateway

--- a/apps/jan-api-gateway/application/cmd/server/server.go
+++ b/apps/jan-api-gateway/application/cmd/server/server.go
@@ -2,14 +2,14 @@ package main
 
 import (
 	"context"
-
+	nethttp "net/http"
 	_ "net/http/pprof"
 
 	_ "github.com/grafana/pyroscope-go/godeltaprof/http/pprof"
 
 	"github.com/mileusna/crontab"
 	"menlo.ai/jan-api-gateway/app/domain/healthcheck"
-	"menlo.ai/jan-api-gateway/app/interfaces/http"
+	apphttp "menlo.ai/jan-api-gateway/app/interfaces/http"
 	janinference "menlo.ai/jan-api-gateway/app/utils/httpclients/jan_inference"
 	"menlo.ai/jan-api-gateway/app/utils/httpclients/serper"
 	"menlo.ai/jan-api-gateway/app/utils/logger"
@@ -17,7 +17,7 @@ import (
 )
 
 type Application struct {
-	HttpServer *http.HttpServer
+	HttpServer *apphttp.HttpServer
 }
 
 func (application *Application) Start() {
@@ -44,13 +44,23 @@ func init() {
 // @name Authorization
 // @description Type "Bearer" followed by a space and JWT token.
 func main() {
-	healthcheckService := healthcheck.NewService(janinference.NewJanInferenceClient(context.Background()))
-	cron := crontab.New()
-	crontabContext := context.Background()
-	healthcheckService.Start(crontabContext, cron)
-	application, err := CreateApplication()
-	if err != nil {
-		panic(err)
-	}
-	application.Start()
+       healthcheckService := healthcheck.NewService(janinference.NewJanInferenceClient(context.Background()))
+       cron := crontab.New()
+       crontabContext := context.Background()
+       healthcheckService.Start(crontabContext, cron)
+
+       // Expose pprof endpoints for profiling (for Grafana Alloy/Pyroscope Go pull mode)
+       go func() {
+	       // Default pprof mux is registered on DefaultServeMux by importing net/http/pprof
+	       // Listen on localhost:6060 (or change port as needed)
+	       if err := nethttp.ListenAndServe("localhost:6060", nil); err != nil {
+		       logger.GetLogger().Errorf("pprof server failed: %v", err)
+	       }
+       }()
+
+       application, err := CreateApplication()
+       if err != nil {
+	       panic(err)
+       }
+       application.Start()
 }


### PR DESCRIPTION
This pull request introduces a new feature to the API gateway server to support runtime profiling. The most significant change is the addition of a background goroutine that exposes pprof endpoints on a local port, which allows for easier performance monitoring and debugging.

**Observability improvements:**

* Added a goroutine in `server.go` to start an HTTP server on `localhost:6060` that exposes Go's built-in pprof endpoints, enabling runtime profiling for tools like Grafana Alloy and Pyroscope.