### PR TITLE
chore: expose pprof endpoint (#57)

### DIFF
--- a/.github/workflows/dev-jan-api-gateway.yml
+++ b/.github/workflows/dev-jan-api-gateway.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - dev
+      - main
     paths:
       - "apps/jan-api-gateway/**"
       - .github/workflows/dev-jan-api-gateway

--- a/apps/jan-api-gateway/application/cmd/server/server.go
+++ b/apps/jan-api-gateway/application/cmd/server/server.go
@@ -2,14 +2,14 @@ package main
 
 import (
 	"context"
-
+	nethttp "net/http"
 	_ "net/http/pprof"
 
 	_ "github.com/grafana/pyroscope-go/godeltaprof/http/pprof"
 
 	"github.com/mileusna/crontab"
 	"menlo.ai/jan-api-gateway/app/domain/healthcheck"
-	"menlo.ai/jan-api-gateway/app/interfaces/http"
+	apphttp "menlo.ai/jan-api-gateway/app/interfaces/http"
 	janinference "menlo.ai/jan-api-gateway/app/utils/httpclients/jan_inference"
 	"menlo.ai/jan-api-gateway/app/utils/httpclients/serper"
 	"menlo.ai/jan-api-gateway/app/utils/logger"
@@ -17,7 +17,7 @@ import (
 )
 
 type Application struct {
-	HttpServer *http.HttpServer
+	HttpServer *apphttp.HttpServer
 }
 
 func (application *Application) Start() {
@@ -44,13 +44,23 @@ func init() {
 // @name Authorization
 // @description Type "Bearer" followed by a space and JWT token.
 func main() {
-	healthcheckService := healthcheck.NewService(janinference.NewJanInferenceClient(context.Background()))
-	cron := crontab.New()
-	crontabContext := context.Background()
-	healthcheckService.Start(crontabContext, cron)
-	application, err := CreateApplication()
-	if err != nil {
-		panic(err)
-	}
-	application.Start()
+       healthcheckService := healthcheck.NewService(janinference.NewJanInferenceClient(context.Background()))
+       cron := crontab.New()
+       crontabContext := context.Background()
+       healthcheckService.Start(crontabContext, cron)
+
+       // Expose pprof endpoints for profiling (for Grafana Alloy/Pyroscope Go pull mode)
+       go func() {
+	       // Default pprof mux is registered on DefaultServeMux by importing net/http/pprof
+	       // Listen on localhost:6060 (or change port as needed)
+	       if err := nethttp.ListenAndServe("localhost:6060", nil); err != nil {
+		       logger.GetLogger().Errorf("pprof server failed: %v", err)
+	       }
+       }()
+
+       application, err := CreateApplication()
+       if err != nil {
+	       panic(err)
+       }
+       application.Start()
 }


### PR DESCRIPTION
This pull request introduces improvements to the development workflow and enhances the observability of the `jan-api-gateway` service. The most important changes include enabling workflow runs on the `main` branch and adding a profiling server for runtime diagnostics.

**Workflow configuration:**

* Updated `.github/workflows/dev-jan-api-gateway.yml` to trigger on both `dev` and `main` branches, ensuring CI/CD processes cover all primary development branches.

**Observability and profiling:**

* In `server.go`, added a background goroutine to start a pprof server on `localhost:6060`, exposing runtime profiling endpoints for debugging and performance monitoring (e.g., for Grafana Alloy/Pyroscope integration).

**Code organization:**

* Standardized import aliases for the HTTP server package (`app/interfaces/http`) and updated the `Application` struct to use the new alias, improving code clarity and maintainability.