### PR TITLE
chore: pprof listen on 0.0.0.0

### DIFF
--- a/apps/jan-api-gateway/application/cmd/server/server.go
+++ b/apps/jan-api-gateway/application/cmd/server/server.go
@@ -53,7 +53,7 @@ func main() {
        go func() {
 	       // Default pprof mux is registered on DefaultServeMux by importing net/http/pprof
 	       // Listen on localhost:6060 (or change port as needed)
-	       if err := nethttp.ListenAndServe("localhost:6060", nil); err != nil {
+	       if err := nethttp.ListenAndServe("0.0.0.0:6060", nil); err != nil {
 		       logger.GetLogger().Errorf("pprof server failed: %v", err)
 	       }
        }()


### PR DESCRIPTION
This pull request makes a small but important update to the pprof debug server configuration in `server.go`. The change modifies the pprof server to listen on all network interfaces instead of just localhost, which allows remote profiling and debugging connections.

- Changed the pprof server to listen on `0.0.0.0:6060` instead of `localhost:6060` in `server.go`, enabling access from external hosts.