### PR TITLE
chore: set up cicd for jan server docs

### DIFF
--- a/.github/workflows/jan-server-docs.yml
+++ b/.github/workflows/jan-server-docs.yml
@@ -1,0 +1,98 @@
+name: Jan server Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/jan-server-docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/jan-server-docs.yml'
+    # Review gh actions docs if you want to further define triggers, paths, etc
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy to CloudFlare Pages
+    env:
+      CLOUDFLARE_PROJECT_NAME: jan-server-docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      deployments: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v2.0.1
+
+      - name: Fill env vars
+        continue-on-error: true
+        working-directory: docs
+        run: |
+          env_example_file=".env.example"
+          touch .env
+          while IFS= read -r line || [[ -n "$line" ]]; do
+            if [[ "$line" == *"="* ]]; then
+              var_name=$(echo $line | cut -d '=' -f 1)
+              echo $var_name
+              var_value="$(jq -r --arg key "$var_name" '.[$key]' <<< "$SECRETS")"
+              echo "$var_name=$var_value" >> .env
+            fi
+          done < "$env_example_file"
+        env:
+          SECRETS: '${{ toJson(secrets) }}'
+
+      - name: Install dependencies
+        working-directory: docs
+        run: bun install
+      - name: Build docs
+        working-directory: docs
+        run: bun run build
+
+      - name: copy redirects and headers
+        continue-on-error: true
+        working-directory: docs
+        run: |
+          cp _redirects dist/_redirects
+          cp _headers dist/_headers
+
+      - name: Publish to Cloudflare Pages PR Preview and Staging
+        if: github.event_name == 'pull_request'
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ env.CLOUDFLARE_PROJECT_NAME }}
+          directory: ./docs/dist
+          # Optional: Enable this if you want to have GitHub Deployments triggered
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+        id: deployCloudflarePages
+
+      - uses: mshick/add-pr-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          message: |
+            Preview URL Jan Server Docs: ${{ steps.deployCloudflarePages.outputs.url }}
+
+      - name: Publish to Cloudflare Pages Production
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ env.CLOUDFLARE_PROJECT_NAME }}
+          directory: ./docs/dist
+          branch: main
+          # Optional: Enable this if you want to have GitHub Deployments triggered
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Pull Request Title: Configure CI/CD to Deploy Jan Server Docs

**Description:**

This PR adds a new GitHub Actions workflow (`jan-server-docs.yml`) to automate the deployment of **Jan Server documentation** to **Cloudflare Pages**.

* Deploys on pushes to `main` affecting `docs/**` or the workflow file.
* Provides PR preview deployments and production deployment.
* Includes environment variable filling, build steps with Bun, and automatic preview link comments on PRs.

---

### Change-Specific Checklist

*No domain, database, or API changes introduced. Only workflow automation for docs deployment.*

