### PR TITLE
feat: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,0 +1,24 @@
+---
+name: 🐛 Bug Report
+about: If something isn't working as expected 🤔
+title: 'bug: '
+type: Bug
+---
+
+**Version:** e.g. 0.5.x-xxx
+
+## Describe the Bug
+<!-- A clear & concise description of the bug -->
+
+
+## Steps to Reproduce
+1.
+
+## Screenshots / Logs
+<!-- You can find logs in: Setting -> General -> Data Folder -> App Logs -->
+
+
+## Operating System
+- [ ] MacOS
+- [ ] Windows
+- [ ] Linux

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,0 +1,12 @@
+---
+name: 🚀 Feature Request
+about: Suggest an idea for this project 😻!
+title: 'idea: '
+type: Idea
+---
+
+## Problem Statement
+<!-- Describe the problem you're facing -->
+
+## Feature Idea
+<!-- Describe what you want instead. Examples are welcome! -->

--- a/.github/ISSUE_TEMPLATE/3-epic.md
+++ b/.github/ISSUE_TEMPLATE/3-epic.md
@@ -1,0 +1,27 @@
+---
+name: 🌟 Epic
+about: User stories and specs
+title: 'epic: '
+type: Epic
+---
+
+## User Stories
+
+- As a [user type], I can [do something] so that [outcome]
+
+## Not in scope
+
+- 
+
+## User Flows & Designs
+
+- Key user flows
+- Figma link
+- Edge cases
+- Error states
+
+## Engineering Decisions
+
+- **Technical Approach:** Brief outline of the solution.
+- **Key Trade-offs:** What’s been considered/rejected and why.
+- **Dependencies:** APIs, services, libraries, teams.

--- a/.github/ISSUE_TEMPLATE/4-goal.md
+++ b/.github/ISSUE_TEMPLATE/4-goal.md
@@ -1,0 +1,24 @@
+---
+name: 🎯 Goal
+about: Roadmap goals for our users
+title: 'goal: '
+type: Goal
+---
+
+## 🎯 Goal  
+<!-- Short description of our goal -->
+
+## 📖 Context  
+<!-- Give a description of our current context -->
+
+## ✅ Scope  
+<!-- High lever description of what we are going to deliver -->
+
+## ❌ Out of Scope  
+<!-- What we are not targeting / delivering / discussing in this goal -->
+
+## 🛠 Deliverables  
+<!-- What we are the tangible deliverables for this goal -->
+
+## ❓Open questions
+<!-- What are we not sure about and need to discuss more -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Jan Server Discussions
+    url: https://github.com/orgs/menloresearch/discussions/categories/q-a
+    about: Get help, discuss features & roadmap, and share your projects


### PR DESCRIPTION
This pull request adds a set of standardized GitHub issue templates and configuration for the project. These templates will help contributors file bug reports, feature requests, epics, and goals in a consistent and structured manner, improving project organization and communication.

Issue template additions:

<img width="721" height="378" alt="image" src="https://github.com/user-attachments/assets/954ed681-b32e-491a-8138-06d7217428a9" />


* Added a bug report template (`.github/ISSUE_TEMPLATE/1-bug-report.md`) to guide users in reporting issues, including sections for version, steps to reproduce, logs, and OS.
* Added a feature request template (`.github/ISSUE_TEMPLATE/2-feature-request.md`) for suggesting new ideas, with prompts for problem statements and feature descriptions.
* Added an epic template (`.github/ISSUE_TEMPLATE/3-epic.md`) for documenting user stories, specs, user flows, and engineering decisions.
* Added a goal template (`.github/ISSUE_TEMPLATE/4-goal.md`) to capture roadmap goals, context, scope, deliverables, and open questions.

Configuration update:

* Enabled blank issues and added a contact link for Jan Server Discussions in the issue template configuration (`.github/ISSUE_TEMPLATE/config.yml`).