### PR TITLE
chore: add ci for vector store

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -29,6 +29,7 @@ jobs:
       mcp-tools: ${{ steps.filter.outputs.mcp-tools }}
       media-api: ${{ steps.filter.outputs.media-api }}
       response-api: ${{ steps.filter.outputs.response-api }}
+      vector-store: ${{ steps.filter.outputs.vector-store }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -39,10 +40,13 @@ jobs:
               - 'services/llm-api/**'
             mcp-tools:
               - 'services/mcp-tools/**'
+              - '!services/mcp-tools/tools/vector-store-service/**'
             media-api:
               - 'services/media-api/**'
             response-api:
               - 'services/response-api/**'
+            vector-store:
+              - 'services/mcp-tools/tools/vector-store-service/**'
 
   build-llm-api:
     needs: changes
@@ -100,6 +104,21 @@ jobs:
       context: services/response-api
       registry-url: registry.menlo.ai
       tags: registry.menlo.ai/jan-server/response-api:dev-${{ github.sha }}
+      is_push: ${{ github.event_name == 'push' }}
+      build-args: |
+        VERSION_TAG=dev-${{ github.sha }}
+
+  build-vector-store:
+    needs: changes
+    if: needs.changes.outputs.vector-store == 'true'
+    uses: ./.github/workflows/template-docker.yml
+    secrets: inherit
+    with:
+      runs-on: ubuntu-24-04-docker
+      docker-file: services/mcp-tools/tools/vector-store-service/Dockerfile
+      context: services/mcp-tools/tools/vector-store-service
+      registry-url: registry.menlo.ai
+      tags: registry.menlo.ai/jan-server/vector-store-service:dev-${{ github.sha }}
       is_push: ${{ github.event_name == 'push' }}
       build-args: |
         VERSION_TAG=dev-${{ github.sha }}

--- a/services/mcp-tools/tools/vector-store-service/README.md
+++ b/services/mcp-tools/tools/vector-store-service/README.md
@@ -20,4 +20,5 @@ go run .
 ```bash
 docker build -t vector-store-service .
 docker run -p 3015:3015 vector-store-service
+
 ```


### PR DESCRIPTION
This pull request adds support for building and deploying the new `vector-store-service` as part of the CI/CD workflow. The main changes involve updating the GitHub Actions configuration to detect changes to the service and trigger its build pipeline, as well as a minor update to the service's README.

**CI/CD workflow enhancements:**

* Added a `vector-store` filter to the changes detection job in `.github/workflows/dev.yml`, enabling conditional builds for the new service.
* Updated the path filters to ensure changes in `services/mcp-tools/tools/vector-store-service/**` only trigger the `vector-store` job, and excluded this path from the broader `mcp-tools` job.
* Introduced a new `build-vector-store` job that builds and pushes the Docker image for `vector-store-service` when relevant changes are detected. This uses the shared Docker build template and sets appropriate build arguments and tags.

**Documentation update:**

* Added a blank line to the code block in `services/mcp-tools/tools/vector-store-service/README.md` for improved readability.