### PR TITLE
chore: fix ci trigger

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,28 +4,10 @@ on:
     branches:
       - main
       - dev-test
-    paths:
-      - "services/llm-api/**"
-      - "services/mcp-tools/**"
-      - "services/media-api/**"
-      - "services/response-api/**"
-      - "services/memory-tools/**"
-      - "pkg/**"
-      - .github/workflows/dev.yml
-      - .github/workflows/template-docker.yml
   pull_request:
     branches:
       - main
       - dev-test
-    paths:
-      - "services/llm-api/**"
-      - "services/mcp-tools/**"
-      - "services/media-api/**"
-      - "services/response-api/**"
-      - "services/memory-tools/**"
-      - "pkg/**"
-      - .github/workflows/dev.yml
-      - .github/workflows/template-docker.yml
 
 jobs:
   changes:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -3,16 +3,6 @@ on:
   push:
     branches:
       - release
-    paths:
-      - "services/llm-api/**"
-      - "services/mcp-tools/**"
-      - "services/media-api/**"
-      - "services/response-api/**"
-      - "services/memory-tools/**"
-      - "pkg/**"
-      - .github/workflows/prod.yml
-      - .github/workflows/template-docker.yml
-
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/services/llm-api/Dockerfile
+++ b/services/llm-api/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_VERSION=1.25
 
 FROM golang:${GO_VERSION} AS builder
+
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/services/mcp-tools/Dockerfile
+++ b/services/mcp-tools/Dockerfile
@@ -18,7 +18,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o mcp-tools .
 FROM alpine:latest
 
 RUN apk --no-cache add ca-certificates
-
 WORKDIR /app
 
 # Copy the binary from builder

--- a/services/media-api/Dockerfile
+++ b/services/media-api/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_VERSION=1.25
 
 FROM golang:${GO_VERSION} as build
+
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/services/memory-tools/Dockerfile
+++ b/services/memory-tools/Dockerfile
@@ -4,7 +4,6 @@ ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /app
-
 # Install build dependencies
 RUN apk add --no-cache git
 

--- a/services/response-api/Dockerfile
+++ b/services/response-api/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_VERSION=1.25
 
 FROM golang:${GO_VERSION} as build
+
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/services/template-api/Dockerfile
+++ b/services/template-api/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_VERSION=1.25
 
 FROM golang:${GO_VERSION} as build
+
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
This pull request primarily updates the CI/CD workflow triggers and makes minor improvements to several Dockerfiles in the project. The most significant change is the simplification of workflow triggers by removing path-based filters, ensuring workflows run on all changes to the specified branches. Additionally, small formatting and consistency improvements are made to Dockerfiles across multiple services.

**CI/CD Workflow Trigger Updates:**

* Removed path-based filters from the `on:` section in `.github/workflows/dev.yml` and `.github/workflows/prod.yml`, so workflows now trigger on any changes to the listed branches, not just specific files or directories. [[1]](diffhunk://#diff-914da273e1d936250929f1160bdd8be46aa865099502b04b471fe734f6b644ddL7-L28) [[2]](diffhunk://#diff-b01f9374f6cc69f1d6b5f14f3c86dd1989076895b0d9d688f8fdddf35296acc6L6-L15)

**Dockerfile Consistency and Formatting:**

* Added a blank line after the `FROM` statement for improved readability in the Dockerfiles for `llm-api`, `media-api`, `response-api`, and `template-api` services. [[1]](diffhunk://#diff-f37d7fb1ea956ac8ad1e4a19dd171aa731c2597e2b6bb4750aba2a454f9156fcR4) [[2]](diffhunk://#diff-2a06b4721b8f40803e188394173d5d5b75e3239793e8a6233a113317363e8971R4) [[3]](diffhunk://#diff-baa11b3a7284ad305c9066fe3bdfd918836676d5d2c9b07f8da54d23540473eeR4) [[4]](diffhunk://#diff-ad4c550a69dfc7f4404e44426bcd11033f195f7e003ad600eb80cd68f8917a09R4)
* Removed an unnecessary blank line and improved formatting in the `memory-tools` and `mcp-tools` Dockerfiles. [[1]](diffhunk://#diff-21d547b6ca32ad97b459689da9fc9d17ba6c36696c14ad5b6dcc5576dacae342L7) [[2]](diffhunk://#diff-81f4ec97ae6fda681e87dee32b676a7a70f3afa047cfb58950a46cd45a99c3c3L21)