### PR TITLE
Fix tool call tracking

### DIFF
--- a/services/llm-api/internal/domain/conversation/item.go
+++ b/services/llm-api/internal/domain/conversation/item.go
@@ -13,7 +13,7 @@ import (
 // Item Types and Enums
 // ===============================================
 
-// @Enum(message, function_call, function_call_output, reasoning, file_search_call, web_search_call, image_generation_call, computer_call, computer_call_output, code_interpreter_call, local_shell_call, local_shell_call_output, shell_call, shell_call_output, apply_patch_call, apply_patch_call_output, mcp_list_tools, mcp_approval_request, mcp_approval_response, mcp_call, mcp_call_output, custom_tool_call, custom_tool_call_output)
+// @Enum(message, function_call, function_call_output, reasoning, file_search_call, web_search_call, image_generation_call, computer_call, computer_call_output, code_interpreter_call, local_shell_call, local_shell_call_output, shell_call, shell_call_output, apply_patch_call, apply_patch_call_output, mcp_list_tools, mcp_approval_request, mcp_approval_response, mcp_call, custom_tool_call, custom_tool_call_output)
 type ItemType string
 
 const (
@@ -42,7 +42,6 @@ const (
 	ItemTypeMcpApprovalRequest  ItemType = "mcp_approval_request"
 	ItemTypeMcpApprovalResponse ItemType = "mcp_approval_response"
 	ItemTypeMcpCall             ItemType = "mcp_call"
-	ItemTypeMcpCallOutput       ItemType = "mcp_call_output"
 
 	// Custom tool types
 	ItemTypeCustomToolCall       ItemType = "custom_tool_call"
@@ -66,7 +65,7 @@ func ValidateItemType(input string) bool {
 		ItemTypeLocalShellCall, ItemTypeLocalShellCallOutput,
 		ItemTypeShellCall, ItemTypeShellCallOutput,
 		ItemTypeApplyPatchCall, ItemTypeApplyPatchCallOutput,
-		ItemTypeMcpListTools, ItemTypeMcpApprovalRequest, ItemTypeMcpApprovalResponse, ItemTypeMcpCall, ItemTypeMcpCallOutput,
+		ItemTypeMcpListTools, ItemTypeMcpApprovalRequest, ItemTypeMcpApprovalResponse, ItemTypeMcpCall,
 		ItemTypeCustomToolCall, ItemTypeCustomToolCallOutput,
 		// Legacy types
 		ItemTypeFileSearch, ItemTypeWebSearch, ItemTypeCodeInterpreter,
@@ -444,6 +443,7 @@ type Item struct {
 
 	// OpenAI-compatible fields for specific item types
 	CallID                   *string                `json:"call_id,omitempty"`                      // For function/tool calls
+	Name                     *string                `json:"name,omitempty"`                         // For MCP tool calls - tool name
 	ServerLabel              *string                `json:"server_label,omitempty"`                 // For MCP calls
 	ApprovalRequestID        *string                `json:"approval_request_id,omitempty"`          // For MCP approval
 	Arguments                *string                `json:"arguments,omitempty"`                    // For tool calls (JSON string)
@@ -1014,7 +1014,7 @@ func (c Content) MarshalJSON() ([]byte, error) {
 
 	// Determine what to use for the text field based on content type
 	switch c.Type {
-	case "input_text", "reasoning_text", "tool_result", "text", "mcp_call_output":
+	case "input_text", "reasoning_text", "tool_result", "text", "mcp_call":
 		// Use simple string for these types
 		if c.TextString != nil {
 			aux.Text = *c.TextString
@@ -1041,7 +1041,7 @@ func (c *Content) UnmarshalJSON(data []byte) error {
 	// Parse the text field based on content type
 	if len(aux.Text) > 0 {
 		switch c.Type {
-		case "input_text", "reasoning_text", "tool_result", "text", "mcp_call_output":
+		case "input_text", "reasoning_text", "tool_result", "text", "mcp_call":
 			// Try to unmarshal as string
 			var textStr string
 			if err := json.Unmarshal(aux.Text, &textStr); err == nil {

--- a/services/llm-api/internal/interfaces/httpserver/requests/conversation/conversation.go
+++ b/services/llm-api/internal/interfaces/httpserver/requests/conversation/conversation.go
@@ -46,10 +46,18 @@ type GetItemQueryParams struct {
 	Include []string `form:"include"`
 }
 
-// UpdateItemByCallIDRequest represents the request to update an item's status and output by call_id
+// UpdateItemByCallIDRequest represents the request to update an mcp_call item by call_id
 // Used by MCP tools to report tool execution results
 type UpdateItemByCallIDRequest struct {
+	// Required fields
 	Status *string `json:"status" binding:"required"` // "completed", "failed", "cancelled"
-	Output *string `json:"output,omitempty"`          // Result of the tool execution
-	Error  *string `json:"error,omitempty"`           // Error message if status is "failed"
+
+	// Result fields
+	Output *string `json:"output,omitempty"` // Result of the tool execution (JSON string)
+	Error  *string `json:"error,omitempty"`  // Error message if status is "failed"
+
+	// Tool info fields (optional - already set on creation, but can be updated)
+	Name        *string `json:"name,omitempty"`         // Tool name
+	Arguments   *string `json:"arguments,omitempty"`    // JSON string of arguments
+	ServerLabel *string `json:"server_label,omitempty"` // MCP server label
 }

--- a/services/llm-api/migrations/000010_add_mcp_tracking_indexes.up.sql
+++ b/services/llm-api/migrations/000010_add_mcp_tracking_indexes.up.sql
@@ -4,12 +4,12 @@
 
 -- Add composite index on (conversation_id, call_id) for efficient lookup
 -- This is used by the PATCH endpoint to update MCP tool call results
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_conversation_items_conv_call_id 
+CREATE INDEX IF NOT EXISTS idx_conversation_items_conv_call_id 
 ON llm_api.conversation_items(conversation_id, call_id) 
 WHERE call_id IS NOT NULL;
 
 -- Add index on status for filtering pending/in_progress tool calls
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_conversation_items_status 
+CREATE INDEX IF NOT EXISTS idx_conversation_items_status 
 ON llm_api.conversation_items(status) 
 WHERE status IN ('in_progress', 'incomplete');
 

--- a/services/mcp-tools/internal/interfaces/httpserver/routes/mcp/memory_mcp.go
+++ b/services/mcp-tools/internal/interfaces/httpserver/routes/mcp/memory_mcp.go
@@ -249,18 +249,27 @@ func (m *MemoryMCP) RegisterTools(server *mcp.Server) {
 
 		// Update tool call result in LLM-API (async)
 		if trackingEnabled && m.llmClient != nil {
+			// Capture input for async goroutine
+			inputCopy := input
 			go func() {
 				saveCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 
 				// Marshal result for storage
 				resultJSON, _ := json.Marshal(result)
+
+				// Serialize arguments
+				argsBytes, _ := json.Marshal(inputCopy)
+				argsStr := string(argsBytes)
+
 				saveResult := m.llmClient.UpdateToolCallResult(
 					saveCtx,
 					tracking.AuthToken,
 					tracking.ConversationID,
 					tracking.ToolCallID,
 					"memory_retrieve",
+					argsStr,
+					"Jan MCP Server",
 					string(resultJSON),
 					nil, // no error
 				)

--- a/services/mcp-tools/internal/interfaces/httpserver/routes/mcp/sandboxfusion_mcp.go
+++ b/services/mcp-tools/internal/interfaces/httpserver/routes/mcp/sandboxfusion_mcp.go
@@ -133,12 +133,18 @@ func (s *SandboxFusionMCP) RegisterTools(server *mcp.Server) {
 
 		// If tracking is enabled, save result to LLM-API
 		if trackingEnabled && s.llmClient != nil {
+			// Capture input for async goroutine
+			inputCopy := input
 			go func() {
 				saveCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 
 				outputBytes, _ := json.Marshal(payload)
 				outputStr := string(outputBytes)
+
+				// Serialize arguments
+				argsBytes, _ := json.Marshal(inputCopy)
+				argsStr := string(argsBytes)
 
 				var errStr *string
 				if toolErr != nil {
@@ -152,6 +158,8 @@ func (s *SandboxFusionMCP) RegisterTools(server *mcp.Server) {
 					tracking.ConversationID,
 					tracking.ToolCallID,
 					"python_exec",
+					argsStr,
+					"Jan MCP Server",
 					outputStr,
 					errStr,
 				)

--- a/services/mcp-tools/internal/interfaces/httpserver/routes/mcp/serper_mcp.go
+++ b/services/mcp-tools/internal/interfaces/httpserver/routes/mcp/serper_mcp.go
@@ -193,6 +193,8 @@ func (s *SerperMCP) RegisterTools(server *mcp.Server) {
 
 		// If tracking is enabled, save result to LLM-API (single PATCH call)
 		if trackingEnabled && s.llmClient != nil {
+			// Capture input for async goroutine
+			inputCopy := input
 			go func() {
 				saveCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
@@ -201,19 +203,25 @@ func (s *SerperMCP) RegisterTools(server *mcp.Server) {
 				outputBytes, _ := json.Marshal(payload)
 				outputStr := string(outputBytes)
 
+				// Serialize arguments
+				argsBytes, _ := json.Marshal(inputCopy)
+				argsStr := string(argsBytes)
+
 				var errStr *string
 				if toolErr != nil {
 					e := toolErr.Error()
 					errStr = &e
 				}
 
-				// Update the pending item to completed
+				// Update the in_progress item to completed
 				result := s.llmClient.UpdateToolCallResult(
 					saveCtx,
 					tracking.AuthToken,
 					tracking.ConversationID,
 					tracking.ToolCallID,
 					"google_search",
+					argsStr,
+					"Jan MCP Server",
 					outputStr,
 					errStr,
 				)
@@ -281,12 +289,18 @@ func (s *SerperMCP) RegisterTools(server *mcp.Server) {
 
 		// If tracking is enabled, save result to LLM-API
 		if trackingEnabled && s.llmClient != nil {
+			// Capture input for async goroutine
+			inputCopy := input
 			go func() {
 				saveCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 
 				outputBytes, _ := json.Marshal(payload)
 				outputStr := string(outputBytes)
+
+				// Serialize arguments
+				argsBytes, _ := json.Marshal(inputCopy)
+				argsStr := string(argsBytes)
 
 				var errStr *string
 				if toolErr != nil {
@@ -300,6 +314,8 @@ func (s *SerperMCP) RegisterTools(server *mcp.Server) {
 					tracking.ConversationID,
 					tracking.ToolCallID,
 					"scrape",
+					argsStr,
+					"Jan MCP Server",
 					outputStr,
 					errStr,
 				)


### PR DESCRIPTION
- Eliminated the mcp_call_output item type entirely from the domain model
- Modified MCP tool handlers (serper, sandboxfusion, memory) to pass tool name, arguments, and server label in the PATCH request
- Updated the LLM-API conversation handler to update a single mcp_call item instead of separate request/response items
- Fixed concurrency issues by creating explicit copies of input variables before async goroutines
- Removed CONCURRENTLY keyword from database index creation migration