### PR TITLE
Improves the title truncation logic in the TruncateTitle function

### DIFF
--- a/services/llm-api/internal/utils/stringutils/title.go
+++ b/services/llm-api/internal/utils/stringutils/title.go
@@ -51,13 +51,22 @@ func TruncateTitle(title string, maxLen int) string {
 		return title
 	}
 
-	// Find a good breaking point (end of word)
-	truncated := title[:maxLen]
-	minLen := maxLen / 2 // At least half the max length
-	if lastSpace := strings.LastIndex(truncated, " "); lastSpace > minLen {
-		return title[:lastSpace] + "..."
+	// Reserve space for ellipsis so the final string never exceeds maxLen
+	ellipsis := "..."
+	contentLimit := maxLen - len(ellipsis)
+	if contentLimit < 0 {
+		contentLimit = 0
 	}
-	return truncated + "..."
+
+	truncated := title[:contentLimit]
+	minLen := contentLimit / 2 // At least half the max content length
+
+	// Prefer to cut on a word boundary when possible
+	if lastSpace := strings.LastIndex(truncated, " "); lastSpace > minLen {
+		truncated = strings.TrimRight(truncated[:lastSpace], " ")
+	}
+
+	return truncated + ellipsis
 }
 
 // GenerateTitle creates a clean, truncated title from content


### PR DESCRIPTION
Improves the title truncation logic in the TruncateTitle function to ensure that the final output respects the maximum length constraint by pre-calculating space needed for the ellipsis. The function is used across the codebase to generate conversation titles with limits of 60 characters (auto-generated from chat messages) and 256 characters (user-provided titles).

Key Changes:
- Pre-calculates contentLimit by subtracting ellipsis length from maxLen to ensure final output never exceeds the limit
- Adds explicit handling for edge cases where maxLen is less than ellipsis length (clamping contentLimit to 0)
- Improves word boundary truncation by trimming trailing spaces after cutting at the last space