### PR TITLE
add instruct setup

### DIFF
--- a/services/llm-api/internal/domain/model/model_catalog.go
+++ b/services/llm-api/internal/domain/model/model_catalog.go
@@ -51,6 +51,7 @@ type ModelCatalog struct {
 	SupportsImages     bool   `json:"supports_images"`
 	SupportsEmbeddings bool   `json:"supports_embeddings"`
 	SupportsReasoning  bool   `json:"supports_reasoning"`
+	SupportsInstruct   bool   `json:"supports_instruct"` // Model can use an instruct backup (shows backup dropdown in admin)
 	SupportsAudio      bool   `json:"supports_audio"`
 	SupportsVideo      bool   `json:"supports_video"`
 	SupportsTools      bool   `json:"supports_tools"`
@@ -73,6 +74,7 @@ type ModelCatalogFilter struct {
 	SupportsImages      *bool
 	SupportsEmbeddings  *bool
 	SupportsReasoning   *bool
+	SupportsInstruct    *bool
 	SupportsAudio       *bool
 	SupportsVideo       *bool
 	SupportsTools       *bool

--- a/services/llm-api/internal/domain/model/provider_model.go
+++ b/services/llm-api/internal/domain/model/provider_model.go
@@ -78,6 +78,7 @@ type ProviderModel struct {
 	ReasoningConfig         *ReasoningConfig `json:"reasoning_config,omitempty"`
 	ProviderFlags           map[string]any   `json:"provider_flags,omitempty"`
 	Active                  bool             `json:"active"`
+	InstructModelID         *uint            `json:"instruct_model_id,omitempty"` // Self-referencing FK to the instruct model variant (used when enable_thinking=false)
 	CreatedAt               time.Time        `json:"created_at"`
 	UpdatedAt               time.Time        `json:"updated_at"`
 }

--- a/services/llm-api/internal/domain/model/provider_model_service.go
+++ b/services/llm-api/internal/domain/model/provider_model_service.go
@@ -135,6 +135,26 @@ func (s *ProviderModelService) FindByPublicID(ctx context.Context, publicID stri
 	return s.providerModelRepo.FindByPublicID(ctx, publicID)
 }
 
+// FindByID finds a provider model by its internal ID
+func (s *ProviderModelService) FindByID(ctx context.Context, id uint) (*ProviderModel, error) {
+	if id == 0 {
+		return nil, platformerrors.NewError(ctx, platformerrors.LayerDomain, platformerrors.ErrorTypeValidation, "provider model ID is required", nil, "8a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d")
+	}
+
+	return s.providerModelRepo.FindByID(ctx, id)
+}
+
+// FindByIDs finds provider models by their internal IDs
+func (s *ProviderModelService) FindByIDs(ctx context.Context, ids []uint) ([]*ProviderModel, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	return s.providerModelRepo.FindByFilter(ctx, ProviderModelFilter{
+		IDs: &ids,
+	}, nil)
+}
+
 func (s *ProviderModelService) Update(ctx context.Context, providerModel *ProviderModel) (*ProviderModel, error) {
 	if providerModel == nil {
 		return nil, platformerrors.NewError(ctx, platformerrors.LayerDomain, platformerrors.ErrorTypeValidation, "provider model cannot be nil", nil, "45c19f50-e0d1-4745-b6c4-be6de6ce0ec0")

--- a/services/llm-api/internal/infrastructure/database/dbschema/model_catalog.go
+++ b/services/llm-api/internal/infrastructure/database/dbschema/model_catalog.go
@@ -33,6 +33,7 @@ type ModelCatalog struct {
 	SupportsImages     *bool  `gorm:"not null;default:false;index"`
 	SupportsEmbeddings *bool  `gorm:"not null;default:false;index"`
 	SupportsReasoning  *bool  `gorm:"not null;default:false;index"`
+	SupportsInstruct   *bool  `gorm:"not null;default:false;index"` // Model can use an instruct backup
 	SupportsAudio      *bool  `gorm:"not null;default:false;index"`
 	SupportsVideo      *bool  `gorm:"not null;default:false;index"`
 	SupportsTools      *bool  `gorm:"not null;default:true;index"`
@@ -76,6 +77,7 @@ func NewSchemaModelCatalog(m *domainmodel.ModelCatalog) (*ModelCatalog, error) {
 	supportsImages := m.SupportsImages
 	supportsEmbeddings := m.SupportsEmbeddings
 	supportsReasoning := m.SupportsReasoning
+	supportsInstruct := m.SupportsInstruct
 	supportsAudio := m.SupportsAudio
 	supportsVideo := m.SupportsVideo
 	supportsTools := m.SupportsTools
@@ -104,6 +106,7 @@ func NewSchemaModelCatalog(m *domainmodel.ModelCatalog) (*ModelCatalog, error) {
 		SupportsImages:      &supportsImages,
 		SupportsEmbeddings:  &supportsEmbeddings,
 		SupportsReasoning:   &supportsReasoning,
+		SupportsInstruct:    &supportsInstruct,
 		SupportsAudio:       &supportsAudio,
 		SupportsVideo:       &supportsVideo,
 		SupportsTools:       &supportsTools,
@@ -158,6 +161,10 @@ func (m *ModelCatalog) EtoD() (*domainmodel.ModelCatalog, error) {
 	if m.SupportsReasoning != nil {
 		supportsReasoning = *m.SupportsReasoning
 	}
+	supportsInstruct := false
+	if m.SupportsInstruct != nil {
+		supportsInstruct = *m.SupportsInstruct
+	}
 	supportsAudio := false
 	if m.SupportsAudio != nil {
 		supportsAudio = *m.SupportsAudio
@@ -196,6 +203,7 @@ func (m *ModelCatalog) EtoD() (*domainmodel.ModelCatalog, error) {
 		SupportsImages:      supportsImages,
 		SupportsEmbeddings:  supportsEmbeddings,
 		SupportsReasoning:   supportsReasoning,
+		SupportsInstruct:    supportsInstruct,
 		SupportsAudio:       supportsAudio,
 		SupportsVideo:       supportsVideo,
 		SupportsTools:       supportsTools,

--- a/services/llm-api/internal/infrastructure/database/dbschema/provider_model.go
+++ b/services/llm-api/internal/infrastructure/database/dbschema/provider_model.go
@@ -33,6 +33,7 @@ type ProviderModel struct {
 	ReasoningConfig         datatypes.JSON `gorm:"type:jsonb"`
 	ProviderFlags           datatypes.JSON `gorm:"type:jsonb"`
 	Active                  *bool          `gorm:"not null;default:true;index;index:idx_provider_model_active,priority:2;index:idx_provider_model_catalog_active,priority:3"`
+	InstructModelID         *uint          `gorm:"index"` // Self-referencing FK to the instruct model variant (used when enable_thinking=false)
 }
 
 func NewSchemaProviderModel(m *domainmodel.ProviderModel) (*ProviderModel, error) {
@@ -98,6 +99,7 @@ func NewSchemaProviderModel(m *domainmodel.ProviderModel) (*ProviderModel, error
 		ReasoningConfig:         reasoningConfig,
 		ProviderFlags:           providerFlags,
 		Active:                  &active,
+		InstructModelID:         m.InstructModelID,
 	}, nil
 }
 
@@ -168,6 +170,7 @@ func (m *ProviderModel) EtoD() (*domainmodel.ProviderModel, error) {
 		ReasoningConfig:         reasoningConfig,
 		ProviderFlags:           providerFlags,
 		Active:                  active,
+		InstructModelID:         m.InstructModelID,
 		CreatedAt:               m.CreatedAt,
 		UpdatedAt:               m.UpdatedAt,
 	}, nil

--- a/services/llm-api/internal/infrastructure/database/gormgen/model_catalogs.gen.go
+++ b/services/llm-api/internal/infrastructure/database/gormgen/model_catalogs.gen.go
@@ -49,6 +49,7 @@ func newModelCatalog(db *gorm.DB, opts ...gen.DOOption) modelCatalog {
 	_modelCatalog.SupportsImages = field.NewBool(tableName, "supports_images")
 	_modelCatalog.SupportsEmbeddings = field.NewBool(tableName, "supports_embeddings")
 	_modelCatalog.SupportsReasoning = field.NewBool(tableName, "supports_reasoning")
+	_modelCatalog.SupportsInstruct = field.NewBool(tableName, "supports_instruct")
 	_modelCatalog.SupportsAudio = field.NewBool(tableName, "supports_audio")
 	_modelCatalog.SupportsVideo = field.NewBool(tableName, "supports_video")
 	_modelCatalog.SupportsTools = field.NewBool(tableName, "supports_tools")
@@ -84,6 +85,7 @@ type modelCatalog struct {
 	SupportsImages      field.Bool
 	SupportsEmbeddings  field.Bool
 	SupportsReasoning   field.Bool
+	SupportsInstruct    field.Bool
 	SupportsAudio       field.Bool
 	SupportsVideo       field.Bool
 	SupportsTools       field.Bool
@@ -125,6 +127,7 @@ func (m *modelCatalog) updateTableName(table string) *modelCatalog {
 	m.SupportsImages = field.NewBool(table, "supports_images")
 	m.SupportsEmbeddings = field.NewBool(table, "supports_embeddings")
 	m.SupportsReasoning = field.NewBool(table, "supports_reasoning")
+	m.SupportsInstruct = field.NewBool(table, "supports_instruct")
 	m.SupportsAudio = field.NewBool(table, "supports_audio")
 	m.SupportsVideo = field.NewBool(table, "supports_video")
 	m.SupportsTools = field.NewBool(table, "supports_tools")
@@ -145,7 +148,7 @@ func (m *modelCatalog) GetFieldByName(fieldName string) (field.OrderExpr, bool) 
 }
 
 func (m *modelCatalog) fillFieldMap() {
-	m.fieldMap = make(map[string]field.Expr, 25)
+	m.fieldMap = make(map[string]field.Expr, 26)
 	m.fieldMap["id"] = m.ID
 	m.fieldMap["created_at"] = m.CreatedAt
 	m.fieldMap["updated_at"] = m.UpdatedAt
@@ -167,6 +170,7 @@ func (m *modelCatalog) fillFieldMap() {
 	m.fieldMap["supports_images"] = m.SupportsImages
 	m.fieldMap["supports_embeddings"] = m.SupportsEmbeddings
 	m.fieldMap["supports_reasoning"] = m.SupportsReasoning
+	m.fieldMap["supports_instruct"] = m.SupportsInstruct
 	m.fieldMap["supports_audio"] = m.SupportsAudio
 	m.fieldMap["supports_video"] = m.SupportsVideo
 	m.fieldMap["supports_tools"] = m.SupportsTools

--- a/services/llm-api/internal/infrastructure/database/repository/modelrepo/model_catalog_repository.go
+++ b/services/llm-api/internal/infrastructure/database/repository/modelrepo/model_catalog_repository.go
@@ -56,6 +56,9 @@ func (repo *ModelCatalogGormRepository) applyFilter(query *gormgen.Query, sql go
 	if filter.SupportsReasoning != nil {
 		sql = sql.Where(query.ModelCatalog.SupportsReasoning.Is(*filter.SupportsReasoning))
 	}
+	if filter.SupportsInstruct != nil {
+		sql = sql.Where(query.ModelCatalog.SupportsInstruct.Is(*filter.SupportsInstruct))
+	}
 	if filter.SupportsAudio != nil {
 		sql = sql.Where(query.ModelCatalog.SupportsAudio.Is(*filter.SupportsAudio))
 	}

--- a/services/llm-api/internal/interfaces/httpserver/handlers/chathandler/chat_handler.go
+++ b/services/llm-api/internal/interfaces/httpserver/handlers/chathandler/chat_handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
 	openai "github.com/sashabaranov/go-openai"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -192,6 +193,20 @@ func (h *ChatHandler) CreateChatCompletion(
 		return nil, err
 	}
 
+	// Check if we should use the instruct model instead
+	// This happens when enable_thinking is explicitly false and the model has an instruct model configured
+	if request.EnableThinking != nil && !*request.EnableThinking && selectedProviderModel.InstructModelID != nil {
+		instructModel, instructProvider, err := h.providerHandler.GetProviderModelByID(ctx, *selectedProviderModel.InstructModelID)
+		if err == nil && instructModel != nil && instructProvider != nil {
+			observability.AddSpanEvent(ctx, "switching_to_instruct_model",
+				attribute.String("original_model", selectedProviderModel.ModelPublicID),
+				attribute.String("instruct_model", instructModel.ModelPublicID),
+			)
+			selectedProviderModel = instructModel
+			selectedProvider = instructProvider
+		}
+	}
+
 	// Add provider information to span
 	observability.AddSpanAttributes(ctx,
 		attribute.String("provider.display_name", selectedProvider.DisplayName),
@@ -301,6 +316,10 @@ func (h *ChatHandler) CreateChatCompletion(
 	if modelCatalog != nil {
 		h.applyModelDefaultsFromCatalog(&llmRequest, modelCatalog)
 	}
+
+	// Log all messages before calling the inference engine
+	h.logMessagesBeforeInference(ctx, llmRequest.Messages, request.Model)
+
 	observability.AddSpanEvent(ctx, "calling_llm")
 	llmStartTime := time.Now()
 	if request.Stream {
@@ -1270,4 +1289,76 @@ func (h *ChatHandler) writeSSEData(reqCtx *gin.Context, data string) error {
 	}
 	reqCtx.Writer.Flush()
 	return nil
+}
+
+// logMessagesBeforeInference logs all messages before calling the inference engine
+// This is useful for debugging and auditing what gets sent to the LLM
+func (h *ChatHandler) logMessagesBeforeInference(ctx context.Context, messages []openai.ChatCompletionMessage, model string) {
+	log.Info().
+		Str("model", model).
+		Int("message_count", len(messages)).
+		Msg("Messages before inference")
+
+	for i, msg := range messages {
+		// Truncate content for logging if too long
+		content := msg.Content
+		if len(content) > 500 {
+			content = content[:500] + "... [truncated]"
+		}
+
+		// Handle multipart content
+		multiPartContent := ""
+		if msg.MultiContent != nil && len(msg.MultiContent) > 0 {
+			parts := make([]string, 0, len(msg.MultiContent))
+			for _, part := range msg.MultiContent {
+				switch part.Type {
+				case openai.ChatMessagePartTypeText:
+					text := part.Text
+					if len(text) > 200 {
+						text = text[:200] + "..."
+					}
+					parts = append(parts, fmt.Sprintf("text:%s", text))
+				case openai.ChatMessagePartTypeImageURL:
+					if part.ImageURL != nil {
+						url := part.ImageURL.URL
+						if len(url) > 100 {
+							url = url[:100] + "..."
+						}
+						parts = append(parts, fmt.Sprintf("image:%s", url))
+					}
+				}
+			}
+			multiPartContent = strings.Join(parts, ", ")
+		}
+
+		// Log tool calls if present
+		toolCallInfo := ""
+		if len(msg.ToolCalls) > 0 {
+			toolNames := make([]string, 0, len(msg.ToolCalls))
+			for _, tc := range msg.ToolCalls {
+				toolNames = append(toolNames, tc.Function.Name)
+			}
+			toolCallInfo = strings.Join(toolNames, ", ")
+		}
+
+		logEvent := log.Debug().
+			Int("index", i).
+			Str("role", msg.Role).
+			Str("content", content)
+
+		if multiPartContent != "" {
+			logEvent = logEvent.Str("multi_content", multiPartContent)
+		}
+		if msg.Name != "" {
+			logEvent = logEvent.Str("name", msg.Name)
+		}
+		if msg.ToolCallID != "" {
+			logEvent = logEvent.Str("tool_call_id", msg.ToolCallID)
+		}
+		if toolCallInfo != "" {
+			logEvent = logEvent.Str("tool_calls", toolCallInfo)
+		}
+
+		logEvent.Msg("Message")
+	}
 }

--- a/services/llm-api/internal/interfaces/httpserver/handlers/modelhandler/model_catalog_handler.go
+++ b/services/llm-api/internal/interfaces/httpserver/handlers/modelhandler/model_catalog_handler.go
@@ -93,6 +93,9 @@ func (h *ModelCatalogHandler) UpdateCatalog(
 	if req.SupportsReasoning != nil {
 		catalog.SupportsReasoning = *req.SupportsReasoning
 	}
+	if req.SupportsInstruct != nil {
+		catalog.SupportsInstruct = *req.SupportsInstruct
+	}
 	if req.SupportsAudio != nil {
 		catalog.SupportsAudio = *req.SupportsAudio
 	}

--- a/services/llm-api/internal/interfaces/httpserver/handlers/modelhandler/provider_handler.go
+++ b/services/llm-api/internal/interfaces/httpserver/handlers/modelhandler/provider_handler.go
@@ -262,6 +262,25 @@ func (providerHandler *ProviderHandler) GetModelCatalogByID(ctx context.Context,
 	return providerHandler.providerModelService.FindCatalogByID(ctx, id)
 }
 
+// GetProviderModelByID returns a provider model and its provider by internal ID.
+// This is used for instruct model fallback when enable_thinking=false.
+func (providerHandler *ProviderHandler) GetProviderModelByID(ctx context.Context, id uint) (*domainmodel.ProviderModel, *domainmodel.Provider, error) {
+	providerModel, err := providerHandler.providerModelService.FindByID(ctx, id)
+	if err != nil {
+		return nil, nil, platformerrors.AsError(ctx, platformerrors.LayerHandler, err, "failed to find provider model")
+	}
+	if providerModel == nil {
+		return nil, nil, nil
+	}
+
+	provider, err := providerHandler.providerService.GetByID(ctx, providerModel.ProviderID)
+	if err != nil {
+		return nil, nil, platformerrors.AsError(ctx, platformerrors.LayerHandler, err, "failed to get provider")
+	}
+
+	return providerModel, provider, nil
+}
+
 func (h *ProviderHandler) DeleteProvider(ctx context.Context, publicID string) error {
 	if strings.TrimSpace(publicID) == "" {
 		return platformerrors.NewError(ctx, platformerrors.LayerHandler, platformerrors.ErrorTypeValidation, "provider public ID is required", nil, "0c3f68da-0aa4-4a7c-9cec-c22d47c86f8b")

--- a/services/llm-api/internal/interfaces/httpserver/requests/chat/chat.go
+++ b/services/llm-api/internal/interfaces/httpserver/requests/chat/chat.go
@@ -27,6 +27,10 @@ type ChatCompletionRequest struct {
 	// for conducting in-depth investigations with tool usage.
 	// Requires a model with supports_reasoning: true capability.
 	DeepResearch *bool `json:"deep_research,omitempty"`
+	// EnableThinking controls whether reasoning/thinking capabilities should be used.
+	// Defaults to true. When set to false for a model with supports_reasoning: true
+	// and an instruct model configured, the instruct model will be used instead.
+	EnableThinking *bool `json:"enable_thinking,omitempty"`
 }
 
 // ConversationReference can unmarshal from either a string (ID) or an object

--- a/services/llm-api/internal/interfaces/httpserver/requests/models/model.go
+++ b/services/llm-api/internal/interfaces/httpserver/requests/models/model.go
@@ -35,6 +35,7 @@ type UpdateModelCatalogRequest struct {
 	SupportsImages      *bool                            `json:"supports_images"`
 	SupportsEmbeddings  *bool                            `json:"supports_embeddings"`
 	SupportsReasoning   *bool                            `json:"supports_reasoning"`
+	SupportsInstruct    *bool                            `json:"supports_instruct"`
 	SupportsAudio       *bool                            `json:"supports_audio"`
 	SupportsVideo       *bool                            `json:"supports_video"`
 	SupportsTools       *bool                            `json:"supports_tools"`
@@ -44,19 +45,20 @@ type UpdateModelCatalogRequest struct {
 }
 
 type UpdateProviderModelRequest struct {
-	ModelDisplayName    *string                  `json:"model_display_name"`
-	Category            *string                  `json:"category"`
-	CategoryOrderNumber *int                     `json:"category_order_number"`
-	ModelOrderNumber    *int                     `json:"model_order_number"`
-	Pricing             *domainmodel.Pricing     `json:"pricing"`
-	TokenLimits         *domainmodel.TokenLimits `json:"token_limits"`
-	Family              *string                  `json:"family"`
-	SupportsImages      *bool                    `json:"supports_images"`
-	SupportsEmbeddings  *bool                    `json:"supports_embeddings"`
-	SupportsReasoning   *bool                    `json:"supports_reasoning"`
-	SupportsAudio       *bool                    `json:"supports_audio"`
-	SupportsVideo       *bool                    `json:"supports_video"`
-	Active              *bool                    `json:"active"`
+	ModelDisplayName      *string                  `json:"model_display_name"`
+	Category              *string                  `json:"category"`
+	CategoryOrderNumber   *int                     `json:"category_order_number"`
+	ModelOrderNumber      *int                     `json:"model_order_number"`
+	Pricing               *domainmodel.Pricing     `json:"pricing"`
+	TokenLimits           *domainmodel.TokenLimits `json:"token_limits"`
+	Family                *string                  `json:"family"`
+	SupportsImages        *bool                    `json:"supports_images"`
+	SupportsEmbeddings    *bool                    `json:"supports_embeddings"`
+	SupportsReasoning     *bool                    `json:"supports_reasoning"`
+	SupportsAudio         *bool                    `json:"supports_audio"`
+	SupportsVideo         *bool                    `json:"supports_video"`
+	Active                *bool                    `json:"active"`
+	InstructModelPublicID *string                  `json:"instruct_model_public_id"` // Public ID of the instruct model to use when enable_thinking=false
 }
 
 type BulkEnableModelsRequest struct {

--- a/services/llm-api/internal/interfaces/httpserver/responses/model/model.go
+++ b/services/llm-api/internal/interfaces/httpserver/responses/model/model.go
@@ -344,6 +344,7 @@ type ModelCatalogResponse struct {
 	SupportsImages      bool                            `json:"supports_images"`
 	SupportsEmbeddings  bool                            `json:"supports_embeddings"`
 	SupportsReasoning   bool                            `json:"supports_reasoning"`
+	SupportsInstruct    bool                            `json:"supports_instruct"`
 	SupportsAudio       bool                            `json:"supports_audio"`
 	SupportsVideo       bool                            `json:"supports_video"`
 	SupportsTools       bool                            `json:"supports_tools"`
@@ -369,9 +370,11 @@ type ProviderModelResponse struct {
 	SupportsImages          bool                     `json:"supports_images"`
 	SupportsEmbeddings      bool                     `json:"supports_embeddings"`
 	SupportsReasoning       bool                     `json:"supports_reasoning"`
+	SupportsInstruct        bool                     `json:"supports_instruct"`
 	SupportsAudio           bool                     `json:"supports_audio"`
 	SupportsVideo           bool                     `json:"supports_video"`
 	Active                  bool                     `json:"active"`
+	InstructModelPublicID   *string                  `json:"instruct_model_public_id,omitempty"` // Public ID of the instruct model to use when enable_thinking=false
 	CreatedAt               int64                    `json:"created_at"`
 	UpdatedAt               int64                    `json:"updated_at"`
 }
@@ -407,6 +410,7 @@ func BuildModelCatalogResponse(catalog *domainmodel.ModelCatalog) ModelCatalogRe
 		SupportsImages:      catalog.SupportsImages,
 		SupportsEmbeddings:  catalog.SupportsEmbeddings,
 		SupportsReasoning:   catalog.SupportsReasoning,
+		SupportsInstruct:    catalog.SupportsInstruct,
 		SupportsAudio:       catalog.SupportsAudio,
 		SupportsVideo:       catalog.SupportsVideo,
 		SupportsTools:       catalog.SupportsTools,
@@ -420,6 +424,7 @@ func BuildProviderModelResponse(
 	providerModel *domainmodel.ProviderModel,
 	provider *domainmodel.Provider,
 	modelCatalog *domainmodel.ModelCatalog,
+	instructModelPublicID *string,
 ) ProviderModelResponse {
 	var modelCatalogID *string
 	if modelCatalog != nil {
@@ -428,7 +433,7 @@ func BuildProviderModelResponse(
 
 	// Get capabilities from model catalog (canonical source)
 	var family *string
-	var supportsImages, supportsEmbeddings, supportsReasoning, supportsAudio, supportsVideo bool
+	var supportsImages, supportsEmbeddings, supportsReasoning, supportsInstruct, supportsAudio, supportsVideo bool
 	if modelCatalog != nil {
 		if modelCatalog.Family != "" {
 			family = ptr.ToString(modelCatalog.Family)
@@ -436,6 +441,7 @@ func BuildProviderModelResponse(
 		supportsImages = modelCatalog.SupportsImages
 		supportsEmbeddings = modelCatalog.SupportsEmbeddings
 		supportsReasoning = modelCatalog.SupportsReasoning
+		supportsInstruct = modelCatalog.SupportsInstruct
 		supportsAudio = modelCatalog.SupportsAudio
 		supportsVideo = modelCatalog.SupportsVideo
 	}
@@ -457,9 +463,11 @@ func BuildProviderModelResponse(
 		SupportsImages:          supportsImages,
 		SupportsEmbeddings:      supportsEmbeddings,
 		SupportsReasoning:       supportsReasoning,
+		SupportsInstruct:        supportsInstruct,
 		SupportsAudio:           supportsAudio,
 		SupportsVideo:           supportsVideo,
 		Active:                  providerModel.Active,
+		InstructModelPublicID:   instructModelPublicID,
 		CreatedAt:               providerModel.CreatedAt.Unix(),
 		UpdatedAt:               providerModel.UpdatedAt.Unix(),
 	}

--- a/services/llm-api/migrations/000014_add_supports_instruct.down.sql
+++ b/services/llm-api/migrations/000014_add_supports_instruct.down.sql
@@ -1,0 +1,13 @@
+-- Rollback Migration 000014: Remove supports_instruct and instruct_model_id
+
+-- Drop index first
+DROP INDEX IF EXISTS llm_api.idx_provider_models_instruct_model_id;
+
+-- Remove instruct_model_id column from provider_models table
+ALTER TABLE llm_api.provider_models DROP COLUMN IF EXISTS instruct_model_id;
+
+-- Drop index first
+DROP INDEX IF EXISTS llm_api.idx_model_catalogs_supports_instruct;
+
+-- Remove supports_instruct column from model_catalogs table
+ALTER TABLE llm_api.model_catalogs DROP COLUMN IF EXISTS supports_instruct;

--- a/services/llm-api/migrations/000014_add_supports_instruct.up.sql
+++ b/services/llm-api/migrations/000014_add_supports_instruct.up.sql
@@ -1,0 +1,25 @@
+-- Migration 000014: Add supports_instruct and instruct_model_id for instruct backup feature
+-- supports_instruct on model_catalogs: indicates the model can use an instruct backup
+-- instruct_model_id on provider_models: references the provider_model to use when enable_thinking=false
+
+-- Add supports_instruct column to model_catalogs table
+ALTER TABLE llm_api.model_catalogs 
+    ADD COLUMN IF NOT EXISTS supports_instruct BOOLEAN NOT NULL DEFAULT false;
+
+-- Create index for filtering models by instruct support
+CREATE INDEX IF NOT EXISTS idx_model_catalogs_supports_instruct 
+    ON llm_api.model_catalogs(supports_instruct) WHERE supports_instruct = true;
+
+-- Add comment for documentation
+COMMENT ON COLUMN llm_api.model_catalogs.supports_instruct IS 'Model can use an instruct backup (shows backup dropdown in admin)';
+
+-- Add instruct_model_id column to provider_models table for instruct model fallback
+ALTER TABLE llm_api.provider_models 
+    ADD COLUMN IF NOT EXISTS instruct_model_id BIGINT REFERENCES llm_api.provider_models(id) ON DELETE SET NULL;
+
+-- Create index for the foreign key
+CREATE INDEX IF NOT EXISTS idx_provider_models_instruct_model_id 
+    ON llm_api.provider_models(instruct_model_id) WHERE instruct_model_id IS NOT NULL;
+
+-- Add comment for documentation
+COMMENT ON COLUMN llm_api.provider_models.instruct_model_id IS 'Reference to provider_model to use when enable_thinking=false';


### PR DESCRIPTION
This PR implements an instruct model backup feature that allows reasoning-capable models to fallback to a designated instruct model when enable_thinking is set to false. The implementation adds database schema changes, API request/response fields, and the necessary logic to switch between reasoning and instruct models.

Key Changes:
- Added supports_instruct capability flag to model catalogs and instruct_model_id reference to provider models
- Introduced enable_thinking parameter in chat completion requests to control reasoning behavior
- Implemented model switching logic that uses the instruct model when enable_thinking=false