### PR TITLE
Fix handling invalid format

### DIFF
--- a/services/llm-api/internal/infrastructure/inference/inference_provider.go
+++ b/services/llm-api/internal/infrastructure/inference/inference_provider.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rs/zerolog/log"
+
 	"jan-server/services/llm-api/internal/config"
 	domainmodel "jan-server/services/llm-api/internal/domain/model"
 	"jan-server/services/llm-api/internal/utils/crypto"
@@ -22,12 +24,29 @@ func NewInferenceProvider() *InferenceProvider {
 }
 
 func (ip *InferenceProvider) GetChatCompletionClient(ctx context.Context, provider *domainmodel.Provider) (*chatclient.ChatCompletionClient, error) {
+	log.Debug().
+		Str("provider_id", provider.PublicID).
+		Str("provider_name", provider.DisplayName).
+		Str("base_url", provider.BaseURL).
+		Str("provider_kind", string(provider.Kind)).
+		Msg("[DEBUG] GetChatCompletionClient: creating client for provider")
+
 	client, err := ip.createRestyClient(ctx, provider)
 	if err != nil {
+		log.Error().
+			Err(err).
+			Str("provider_id", provider.PublicID).
+			Str("provider_name", provider.DisplayName).
+			Msg("[DEBUG] GetChatCompletionClient: failed to create resty client")
 		return nil, err
 	}
 
 	clientName := provider.DisplayName
+	log.Debug().
+		Str("provider_name", clientName).
+		Str("base_url", provider.BaseURL).
+		Msg("[DEBUG] GetChatCompletionClient: client created successfully")
+
 	return chatclient.NewChatCompletionClient(client, clientName, provider.BaseURL), nil
 }
 

--- a/services/llm-api/internal/utils/httpclients/chat/chat_completion_client.go
+++ b/services/llm-api/internal/utils/httpclients/chat/chat_completion_client.go
@@ -13,6 +13,7 @@ import (
 	"jan-server/services/llm-api/internal/utils/platformerrors"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
 	"github.com/sashabaranov/go-openai"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -110,6 +111,9 @@ func NewChatCompletionClient(client *resty.Client, name, baseURL string) *ChatCo
 }
 
 func (c *ChatCompletionClient) CreateChatCompletion(ctx context.Context, apiKey string, request CompletionRequest) (*openai.ChatCompletionResponse, error) {
+	// Sanitize messages to remove invalid parts that cause provider validation errors
+	request.Messages = SanitizeMessages(request.Messages)
+
 	// Start OpenTelemetry span for tracking
 	ctx, span := otel.Tracer("chat-completion-client").Start(ctx, "CreateChatCompletion",
 		trace.WithSpanKind(trace.SpanKindClient),
@@ -141,6 +145,13 @@ func (c *ChatCompletionClient) CreateChatCompletion(ctx context.Context, apiKey 
 
 	start := time.Now()
 
+	log.Debug().
+		Str("provider", c.name).
+		Str("base_url", c.baseURL).
+		Str("model", request.Model).
+		Int("message_count", len(request.Messages)).
+		Msg("[DEBUG] CreateChatCompletion: sending request to provider")
+
 	var respBody openai.ChatCompletionResponse
 	resp, err := c.prepareRequest(ctx, apiKey).
 		SetBody(request).
@@ -150,12 +161,40 @@ func (c *ChatCompletionClient) CreateChatCompletion(ctx context.Context, apiKey 
 	duration := time.Since(start)
 
 	if err != nil {
+		log.Error().
+			Err(err).
+			Str("provider", c.name).
+			Str("base_url", c.baseURL).
+			Str("model", request.Model).
+			Dur("duration", duration).
+			Str("error_type", fmt.Sprintf("%T", err)).
+			Msg("[DEBUG] CreateChatCompletion: HTTP request failed")
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		span.SetAttributes(attribute.Int64("llm.duration_ms", duration.Milliseconds()))
 		return nil, err
 	}
 	if resp.IsError() {
+		// Try to get response body for more error details
+		respBodyStr := ""
+		if resp.RawResponse != nil && resp.RawResponse.Body != nil {
+			bodyBytes, _ := io.ReadAll(resp.RawResponse.Body)
+			respBodyStr = string(bodyBytes)
+		}
+		// Also try String() method
+		if respBodyStr == "" {
+			respBodyStr = resp.String()
+		}
+
+		log.Error().
+			Str("provider", c.name).
+			Str("base_url", c.baseURL).
+			Str("model", request.Model).
+			Int("status_code", resp.StatusCode()).
+			Str("response_body", respBodyStr).
+			Dur("duration", duration).
+			Msg("[DEBUG] CreateChatCompletion: provider returned error response")
+
 		reqErr := c.errorFromResponse(ctx, resp, "request failed")
 		span.RecordError(reqErr)
 		span.SetStatus(codes.Error, reqErr.Error())
@@ -165,6 +204,14 @@ func (c *ChatCompletionClient) CreateChatCompletion(ctx context.Context, apiKey 
 		)
 		return nil, reqErr
 	}
+
+	log.Debug().
+		Str("provider", c.name).
+		Str("model", request.Model).
+		Int("status_code", resp.StatusCode()).
+		Int("total_tokens", respBody.Usage.TotalTokens).
+		Dur("duration", duration).
+		Msg("[DEBUG] CreateChatCompletion: request successful")
 
 	// Record token usage and timing in span
 	span.SetAttributes(
@@ -486,6 +533,16 @@ func (c *ChatCompletionClient) errorFromResponse(ctx context.Context, resp *rest
 }
 
 func (c *ChatCompletionClient) doStreamingRequest(ctx context.Context, apiKey string, request CompletionRequest, opts ...StreamOption) (*resty.Response, error) {
+	// Sanitize messages to remove invalid parts that cause provider validation errors
+	request.Messages = SanitizeMessages(request.Messages)
+
+	log.Debug().
+		Str("provider", c.name).
+		Str("base_url", c.baseURL).
+		Str("model", request.Model).
+		Int("message_count", len(request.Messages)).
+		Msg("[DEBUG] doStreamingRequest: starting streaming request")
+
 	req := c.prepareRequest(ctx, apiKey).
 		SetBody(request).
 		SetDoNotParseResponse(true)
@@ -503,15 +560,49 @@ func (c *ChatCompletionClient) doStreamingRequest(ctx context.Context, apiKey st
 
 	resp, err := req.Post(c.endpoint("/chat/completions"))
 	if err != nil {
+		log.Error().
+			Err(err).
+			Str("provider", c.name).
+			Str("base_url", c.baseURL).
+			Str("model", request.Model).
+			Str("error_type", fmt.Sprintf("%T", err)).
+			Msg("[DEBUG] doStreamingRequest: HTTP request failed")
 		return nil, err
 	}
 
 	if resp.IsError() {
+		// Try to read response body for error details
+		respBodyStr := ""
+		if resp.RawResponse != nil && resp.RawResponse.Body != nil {
+			bodyBytes, _ := io.ReadAll(resp.RawResponse.Body)
+			respBodyStr = string(bodyBytes)
+		}
+		if respBodyStr == "" {
+			respBodyStr = resp.String()
+		}
+
+		log.Error().
+			Str("provider", c.name).
+			Str("base_url", c.baseURL).
+			Str("model", request.Model).
+			Int("status_code", resp.StatusCode()).
+			Str("response_body", respBodyStr).
+			Msg("[DEBUG] doStreamingRequest: provider returned error response")
 		return nil, c.errorFromResponse(ctx, resp, "streaming request failed")
 	}
 	if resp.RawResponse == nil || resp.RawResponse.Body == nil {
+		log.Error().
+			Str("provider", c.name).
+			Str("model", request.Model).
+			Msg("[DEBUG] doStreamingRequest: empty response body")
 		return nil, platformerrors.NewError(ctx, platformerrors.LayerDomain, platformerrors.ErrorTypeExternal, "streaming request failed: empty response body", nil, "1b3ab461-dbf9-4034-8abb-dfc6ea8486c5")
 	}
+
+	log.Debug().
+		Str("provider", c.name).
+		Str("model", request.Model).
+		Int("status_code", resp.StatusCode()).
+		Msg("[DEBUG] doStreamingRequest: streaming started successfully")
 
 	return resp, nil
 }
@@ -786,4 +877,49 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// SanitizeMessages removes invalid message parts that would cause validation errors
+// with LLM providers. This includes:
+// - Empty text parts (type: "text" without text field due to omitempty)
+// - Empty image parts (type: "image_url" without URL)
+func SanitizeMessages(messages []openai.ChatCompletionMessage) []openai.ChatCompletionMessage {
+	result := make([]openai.ChatCompletionMessage, 0, len(messages))
+
+	for _, msg := range messages {
+		sanitizedMsg := msg
+
+		// Sanitize MultiContent array if present
+		if len(msg.MultiContent) > 0 {
+			sanitizedParts := make([]openai.ChatMessagePart, 0, len(msg.MultiContent))
+			for _, part := range msg.MultiContent {
+				// Skip empty text parts (would serialize as {"type": "text"} without text field)
+				if part.Type == openai.ChatMessagePartTypeText && part.Text == "" {
+					log.Debug().
+						Str("role", string(msg.Role)).
+						Msg("[DEBUG] SanitizeMessages: skipping empty text part")
+					continue
+				}
+				// Skip empty image parts (no URL)
+				if part.Type == openai.ChatMessagePartTypeImageURL && (part.ImageURL == nil || part.ImageURL.URL == "") {
+					log.Debug().
+						Str("role", string(msg.Role)).
+						Msg("[DEBUG] SanitizeMessages: skipping empty image part")
+					continue
+				}
+				sanitizedParts = append(sanitizedParts, part)
+			}
+
+			// If all parts were filtered out, convert to a simple text message
+			if len(sanitizedParts) == 0 && msg.Content != "" {
+				sanitizedMsg.MultiContent = nil
+			} else {
+				sanitizedMsg.MultiContent = sanitizedParts
+			}
+		}
+
+		result = append(result, sanitizedMsg)
+	}
+
+	return result
 }


### PR DESCRIPTION
This PR fixes handling of invalid message formats that cause validation errors with LLM providers. The fix includes adding message sanitization logic to filter out empty or malformed message parts, along with extensive debug logging throughout the chat completion flow to aid in troubleshooting.

- Introduces SanitizeMessages function to remove empty text and image parts that would fail provider validation
- Adds comprehensive debug logging at multiple layers (client, handler, route, provider) for request/response tracking
- Updates message part filtering in request parsing to prevent empty parts from being sent to providers