### PR TITLE
chore: add ci for realtime api

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,6 +19,7 @@ jobs:
       response-api: ${{ steps.filter.outputs.response-api }}
       memory-tools: ${{ steps.filter.outputs.memory-tools }}
       vector-store: ${{ steps.filter.outputs.vector-store }}
+      realtime-api: ${{ steps.filter.outputs.realtime-api }}
       pkg: ${{ steps.filter.outputs.pkg }}
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +40,8 @@ jobs:
               - 'services/memory-tools/**'
             vector-store:
               - 'services/mcp-tools/tools/vector-store-service/**'
+            realtime-api:
+              - 'services/realtime-api/**'
             pkg:
               - 'pkg/**'
 
@@ -128,6 +131,21 @@ jobs:
       context: services/mcp-tools/tools/vector-store-service
       registry-url: registry.menlo.ai
       tags: registry.menlo.ai/jan-server/vector-store-service:dev-${{ github.sha }}
+      is_push: ${{ github.event_name == 'push' }}
+      build-args: |
+        VERSION_TAG=dev-${{ github.sha }}
+
+  build-realtime-api:
+    needs: changes
+    if: needs.changes.outputs.realtime-api == 'true' || needs.changes.outputs.pkg == 'true'
+    uses: ./.github/workflows/template-docker.yml
+    secrets: inherit
+    with:
+      runs-on: ubuntu-24-04-docker
+      docker-file: services/realtime-api/Dockerfile
+      context: services/realtime-api
+      registry-url: registry.menlo.ai
+      tags: registry.menlo.ai/jan-server/realtime-api-service:dev-${{ github.sha }}
       is_push: ${{ github.event_name == 'push' }}
       build-args: |
         VERSION_TAG=dev-${{ github.sha }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -13,6 +13,7 @@ jobs:
       response-api: ${{ steps.filter.outputs.response-api }}
       memory-tools: ${{ steps.filter.outputs.memory-tools }}
       vector-store: ${{ steps.filter.outputs.vector-store }}
+      realtime-api: ${{ steps.filter.outputs.realtime-api }}
       pkg: ${{ steps.filter.outputs.pkg }}
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +35,8 @@ jobs:
               - 'services/memory-tools/**'
             vector-store:
               - 'services/mcp-tools/tools/vector-store-service/**'
+            realtime-api:
+              - 'services/realtime-api/**'
             pkg:
               - 'pkg/**'
 
@@ -123,6 +126,21 @@ jobs:
       context: services/mcp-tools/tools/vector-store-service
       registry-url: registry.menlo.ai
       tags: registry.menlo.ai/jan-server/vector-store-service:prod-${{ github.sha }}
+      is_push: ${{ github.event_name == 'push' }}
+      build-args: |
+        VERSION_TAG=prod-${{ github.sha }}
+
+  build-realtime-api:
+    needs: changes
+    if: needs.changes.outputs.realtime-api == 'true' || needs.changes.outputs.pkg == 'true'
+    uses: ./.github/workflows/template-docker.yml
+    secrets: inherit
+    with:
+      runs-on: ubuntu-24-04-docker
+      docker-file: services/realtime-api/Dockerfile
+      context: services/realtime-api
+      registry-url: registry.menlo.ai
+      tags: registry.menlo.ai/jan-server/realtime-api:prod-${{ github.sha }}
       is_push: ${{ github.event_name == 'push' }}
       build-args: |
         VERSION_TAG=prod-${{ github.sha }}


### PR DESCRIPTION
This pull request updates the CI/CD workflows to add support for building and deploying the new `realtime-api` service. The main changes are in the development and production GitHub Actions workflows, where logic is added to detect changes in the `realtime-api` service and trigger its Docker build and deployment steps accordingly.

**Workflow automation enhancements:**

* Added a new `realtime-api` key to the list of services monitored for changes in both `.github/workflows/dev.yml` and `.github/workflows/prod.yml`, so changes in `services/realtime-api/**` will trigger related jobs. [[1]](diffhunk://#diff-914da273e1d936250929f1160bdd8be46aa865099502b04b471fe734f6b644ddR43-R44) [[2]](diffhunk://#diff-b01f9374f6cc69f1d6b5f14f3c86dd1989076895b0d9d688f8fdddf35296acc6R38-R39)
* Updated the outputs in the `changes` job to include `realtime-api`, enabling downstream jobs to react to changes in this service. [[1]](diffhunk://#diff-914da273e1d936250929f1160bdd8be46aa865099502b04b471fe734f6b644ddR22) [[2]](diffhunk://#diff-b01f9374f6cc69f1d6b5f14f3c86dd1989076895b0d9d688f8fdddf35296acc6R16)

**Build and deployment pipeline:**

* Introduced a new `build-realtime-api` job in both the dev and prod workflows, which builds and pushes a Docker image for the `realtime-api` service when relevant files or the package directory change. This uses the shared `template-docker.yml` workflow and sets appropriate tags and build arguments. [[1]](diffhunk://#diff-914da273e1d936250929f1160bdd8be46aa865099502b04b471fe734f6b644ddR137-R151) [[2]](diffhunk://#diff-b01f9374f6cc69f1d6b5f14f3c86dd1989076895b0d9d688f8fdddf35296acc6R132-R146)