### PR TITLE
chore: fix ci tag

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -145,7 +145,7 @@ jobs:
       docker-file: services/realtime-api/Dockerfile
       context: services/realtime-api
       registry-url: registry.menlo.ai
-      tags: registry.menlo.ai/jan-server/realtime-api-service:dev-${{ github.sha }}
+      tags: registry.menlo.ai/jan-server/realtime-api:dev-${{ github.sha }}
       is_push: ${{ github.event_name == 'push' }}
       build-args: |
         VERSION_TAG=dev-${{ github.sha }}


### PR DESCRIPTION
This pull request makes a minor update to the Docker image tagging convention in the GitHub Actions workflow for the `realtime-api` service. The change simplifies the image name to improve consistency.

- Changed the Docker image tag from `realtime-api-service` to `realtime-api` in the `.github/workflows/dev.yml` workflow file, ensuring a more consistent and concise naming convention.