### PR TITLE
feat: allow remove convo out of a project

### DIFF
--- a/services/llm-api/internal/domain/conversation/conversation_service.go
+++ b/services/llm-api/internal/domain/conversation/conversation_service.go
@@ -168,8 +168,13 @@ func (s *ConversationService) UpdateConversationWithInput(ctx context.Context, u
 	}
 
 	if input.ProjectID != nil {
-		conversation.ProjectID = input.ProjectID
-		conversation.ProjectPublicID = input.ProjectPublicID
+		if *input.ProjectID == 0 {
+			conversation.ProjectID = nil
+			conversation.ProjectPublicID = nil
+		} else {
+			conversation.ProjectID = input.ProjectID
+			conversation.ProjectPublicID = input.ProjectPublicID
+		}
 		// Clear cached instruction snapshot so the next request pulls the new project's instruction
 		conversation.EffectiveInstructionSnapshot = nil
 	}

--- a/services/llm-api/internal/interfaces/httpserver/handlers/conversationhandler/conversation_handler.go
+++ b/services/llm-api/internal/interfaces/httpserver/handlers/conversationhandler/conversation_handler.go
@@ -176,9 +176,10 @@ func (h *ConversationHandler) UpdateConversation(
 	if req.ProjectID != nil {
 		projectID := strings.TrimSpace(*req.ProjectID)
 		if projectID == "" {
-			// Explicitly clear project association
-			input.ProjectID = nil
-			input.ProjectPublicID = nil
+			zeroID := uint(0)
+			emptyStr := ""
+			input.ProjectID = &zeroID
+			input.ProjectPublicID = &emptyStr
 		} else {
 			// Verify project exists and user has access
 			if h.projectService == nil {


### PR DESCRIPTION
## Summary
Enable users to unassign a conversation from a project by sending an empty project_id in the update request. Previously, passing {"project_id": ""} had no effect due to how nil values were interpreted in the service layer.

## Changes

- Handler when project_id is an empty string, set sentinel values (ProjectID = 0, ProjectPublicID = "") instead of nil
- Service detect sentinel value 0 for ProjectID and explicitly clear the project association