### PR TITLE
feat: return proper error for UNIQUE project name trait

### DIFF
--- a/services/llm-api/internal/domain/project/project.go
+++ b/services/llm-api/internal/domain/project/project.go
@@ -43,6 +43,7 @@ type ProjectRepository interface {
 	Create(ctx context.Context, project *Project) error
 	GetByPublicID(ctx context.Context, publicID string) (*Project, error)
 	GetByPublicIDAndUserID(ctx context.Context, publicID string, userID uint) (*Project, error)
+	GetByNameAndUserID(ctx context.Context, name string, userID uint) (*Project, error)
 	ListByUserID(ctx context.Context, userID uint, pagination *query.Pagination) ([]*Project, int64, error)
 	Update(ctx context.Context, project *Project) error
 	Delete(ctx context.Context, publicID string) error

--- a/services/llm-api/internal/infrastructure/database/repository/projectrepo/project_repository.go
+++ b/services/llm-api/internal/infrastructure/database/repository/projectrepo/project_repository.go
@@ -61,6 +61,19 @@ func (repo *ProjectGormRepository) GetByPublicIDAndUserID(ctx context.Context, p
 	return dbProject.EtoD(), nil
 }
 
+// GetByNameAndUserID implements project.ProjectRepository.
+func (repo *ProjectGormRepository) GetByNameAndUserID(ctx context.Context, name string, userID uint) (*project.Project, error) {
+	var dbProject dbschema.Project
+	err := repo.db.WithContext(ctx).
+		Where("name = ? AND user_id = ? AND deleted_at IS NULL", name, userID).
+		First(&dbProject).Error
+
+	if err != nil {
+		return nil, platformerrors.AsError(ctx, platformerrors.LayerRepository, err, "failed to find project by name and user ID")
+	}
+	return dbProject.EtoD(), nil
+}
+
 // ListByUserID implements project.ProjectRepository.
 func (repo *ProjectGormRepository) ListByUserID(ctx context.Context, userID uint, pagination *query.Pagination) ([]*project.Project, int64, error) {
 	// Build base query

--- a/services/llm-api/internal/interfaces/httpserver/handlers/projecthandler/project_handler.go
+++ b/services/llm-api/internal/interfaces/httpserver/handlers/projecthandler/project_handler.go
@@ -49,6 +49,9 @@ func (h *ProjectHandler) CreateProject(
 	// Persist project
 	proj, err = h.projectService.CreateProject(ctx, proj)
 	if err != nil {
+		if platformerrors.IsErrorType(err, platformerrors.ErrorTypeConflict) {
+			return nil, err
+		}
 		return nil, platformerrors.AsError(ctx, platformerrors.LayerHandler, err, "failed to create project")
 	}
 
@@ -140,6 +143,9 @@ func (h *ProjectHandler) UpdateProject(
 	// Persist changes
 	proj, err = h.projectService.UpdateProject(ctx, proj)
 	if err != nil {
+		if platformerrors.IsErrorType(err, platformerrors.ErrorTypeConflict) {
+			return nil, err
+		}
 		return nil, platformerrors.AsError(ctx, platformerrors.LayerHandler, err, "failed to update project")
 	}
 

--- a/services/llm-api/internal/interfaces/httpserver/responses/response.go
+++ b/services/llm-api/internal/interfaces/httpserver/responses/response.go
@@ -37,10 +37,16 @@ func HandleError(reqCtx *gin.Context, err error, message string) {
 	if errors.As(err, &domainErr) {
 		statusCode := platformerrors.ErrorTypeToHTTPStatus(domainErr.GetErrorType())
 
+		// Use the domain error's message for the response message field if available
+		responseMessage := domainErr.Message
+		if responseMessage == "" {
+			responseMessage = message
+		}
+
 		errResp := ErrorResponse{
 			Code:          domainErr.GetUUID(),
 			Error:         message,
-			Message:       message,
+			Message:       responseMessage,
 			ErrorInstance: domainErr,
 			RequestID:     domainErr.GetRequestID(),
 		}


### PR DESCRIPTION
## Add proper error handling for duplicate project names

### Summary
- Check for existing project with same name before creating/updating projects
- Return HTTP 409 Conflict with project ID in error code and user-friendly message

### Changes
- Check duplicate project with name (or ID) first during the project creation or modification.
- If duplicated, returns the error with format:
```
{
  "code": "proj_abc123xyz", // The proj_ prefix is OpenAI compatible format, which ties in the DB records
  "error": "Failed to create project",
  "message": "Project name already exists"
}
```
