### PR TITLE
add tool instruction and conversation updated at

### DIFF
--- a/services/llm-api/internal/domain/prompt/types.go
+++ b/services/llm-api/internal/domain/prompt/types.go
@@ -29,6 +29,9 @@ type Context struct {
 
 	// Model context for model-specific template resolution
 	ModelCatalogID *string
+
+	// Tools available in the request
+	Tools []openai.Tool
 }
 
 // Module represents a prompt module that can be applied

--- a/services/llm-api/internal/domain/prompttemplate/prompt_template.go
+++ b/services/llm-api/internal/domain/prompttemplate/prompt_template.go
@@ -170,9 +170,27 @@ const DefaultMemoryPrompt = `Use the following personal memory for this user whe
 {{end}}`
 
 // DefaultToolInstructionsPrompt is the default prompt for tool usage guidance
-const DefaultToolInstructionsPrompt = `You have access to various tools. Always choose the best tool for the task.
-When you need to search for information, use web search. When you need to execute code, use the code execution tool.
-Tool usage must respect project instructions and system-level constraints at all times.`
+const DefaultToolInstructionsPrompt = `## Tool Usage Instructions
+
+You have access to the following tools. **ONLY use tools from this list. Do not invent or claim access to tools not listed here.**
+
+AVAILABLE TOOLS:
+{{range .Tools}}- **{{.Name}}**: {{.Description}}
+  - Parameters: {{.Parameters}}
+{{end}}
+CRITICAL RULES:
+1. **Only use tools from the list above** - Never claim access to tools not in this list
+2. **If a tool is not listed, it does not exist** - Do not invent tool names or capabilities
+3. **When asked about available tools**, list ONLY the tools from the list above
+4. Always choose the best tool for the task from the available tools
+5. Tool usage must respect project instructions and system-level constraints at all times
+
+TOOL USAGE PATTERNS:
+{{if .HasSearchTool}}- When you need to search for information: use {{.SearchToolName}}
+{{end}}{{if .HasScrapeTool}}- When you need to scrape or extract content from a webpage: use {{.ScrapeToolName}}
+{{end}}{{if .HasCodeTool}}- When you need to execute code: use {{.CodeToolName}}
+{{end}}{{if .HasBrowserTool}}- When you need to browse the web: use {{.BrowserToolName}}
+{{end}}`
 
 // DefaultCodeAssistantPrompt is the default prompt for code assistance
 const DefaultCodeAssistantPrompt = `When providing code assistance:

--- a/services/llm-api/internal/interfaces/httpserver/handlers/chathandler/chat_handler.go
+++ b/services/llm-api/internal/interfaces/httpserver/handlers/chathandler/chat_handler.go
@@ -276,6 +276,7 @@ func (h *ChatHandler) CreateChatCompletion(
 			ProjectInstruction: projectInstruction,
 			Profile:            profileSettings,
 			ModelCatalogID:     modelCatalogID,
+			Tools:              request.Tools,
 		}
 
 		processedMessages, processErr := h.promptProcessor.Process(ctx, promptCtx, request.Messages)

--- a/services/llm-api/internal/interfaces/httpserver/responses/conversation/conversation.go
+++ b/services/llm-api/internal/interfaces/httpserver/responses/conversation/conversation.go
@@ -10,6 +10,7 @@ type ConversationResponse struct {
 	Object    string            `json:"object"`
 	Title     *string           `json:"title,omitempty"`
 	CreatedAt int64             `json:"created_at"`
+	UpdatedAt int64             `json:"updated_at"`
 	Metadata  map[string]string `json:"metadata,omitempty"`
 	Referrer  *string           `json:"referrer,omitempty"`
 	ProjectID *string           `json:"project_id,omitempty"`
@@ -55,6 +56,7 @@ func NewConversationResponse(conv *conversation.Conversation) *ConversationRespo
 		Object:    "conversation",
 		Title:     conv.Title,
 		CreatedAt: conv.CreatedAt.Unix(),
+		UpdatedAt: conv.UpdatedAt.Unix(),
 		Metadata:  conv.Metadata,
 		Referrer:  conv.Referrer,
 		ProjectID: conv.ProjectPublicID,


### PR DESCRIPTION
Adds two main features: (1) exposes the updated_at timestamp in conversation API responses, and (2) enhances tool instruction prompts to dynamically list available tools from the request context with explicit constraints to prevent tool hallucination.

- Added UpdatedAt field to conversation response structure for API compatibility
- Integrated request tools into prompt processing pipeline to enable dynamic tool instruction generation
- Enhanced tool instruction templates and fallback logic to explicitly list available tools and prevent LLM from inventing non-existent tools