### PR TITLE
fix: order conversations by update date

### DIFF
--- a/services/llm-api/internal/infrastructure/database/repository/conversationrepo/conversation_repository.go
+++ b/services/llm-api/internal/infrastructure/database/repository/conversationrepo/conversation_repository.go
@@ -810,9 +810,9 @@ func (repo *ConversationGormRepository) applyPagination(q *gormgen.Query, sql go
 			}
 		}
 		if p.Order == "desc" {
-			sql = sql.Order(q.Conversation.ID.Desc())
+			sql = sql.Order(q.Conversation.UpdatedAt.Desc())
 		} else {
-			sql = sql.Order(q.Conversation.ID.Asc())
+			sql = sql.Order(q.Conversation.UpdatedAt.Asc())
 		}
 	}
 	return sql


### PR DESCRIPTION
This pull request updates the sorting logic in the conversation pagination implementation to use the `UpdatedAt` timestamp instead of the conversation `ID`. This ensures that conversations are ordered by their last update time, providing a more intuitive and useful ordering for users.

**Pagination and ordering improvements:**

* Changed sorting in the `applyPagination` method of `conversation_repository.go` to order conversations by `UpdatedAt` instead of `ID`, both for ascending and descending order.