### PR TITLE
ci: update jan web base url

### DIFF
--- a/.github/workflows/ci-app-web-dev.yml
+++ b/.github/workflows/ci-app-web-dev.yml
@@ -26,7 +26,7 @@ jobs:
       tags: registry.menlo.ai/jan-server/web:dev-${{ github.sha }}
       build-args: |
         JAN_BASE_URL=https://api-dev.jan.ai/v1
-        JAN_API_BASE_URL=https://api-dev.jan.ai
+        JAN_API_BASE_URL=https://api-dev.jan.ai/
         ENVIRONMENT=dev
         VITE_AUTH_URL=https://auth-dev.jan.ai
         VITE_AUTH_REALM=jan


### PR DESCRIPTION
This pull request includes a minor update to the development workflow configuration. The change ensures that the `JAN_API_BASE_URL` environment variable in `.github/workflows/ci-app-web-dev.yml` consistently includes a trailing slash, which can help prevent issues with URL concatenation in the application.