### PR TITLE
chore: remove proxy image

### DIFF
--- a/apps/platform/Dockerfile
+++ b/apps/platform/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM registry.menlo.ai/dockerhub/node:20-alpine AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 
@@ -13,7 +13,7 @@ ENV NEXT_PUBLIC_JAN_BASE_URL=$NEXT_PUBLIC_JAN_BASE_URL
 RUN npm run build
 
 # Production stage
-FROM registry.menlo.ai/dockerhub/node:20-alpine AS runner
+FROM node:20-alpine AS runner
 
 WORKDIR /app
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM registry.menlo.ai/dockerhub/node:20-alpine AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 
@@ -40,7 +40,7 @@ ENV VITE_REPORT_ISSUE_URL=$VITE_REPORT_ISSUE_URL
 RUN npx vite build
 
 # Production stage
-FROM registry.menlo.ai/dockerhub/nginx:alpine AS runner
+FROM nginx:alpine AS runner
 
 WORKDIR /usr/share/nginx/html
 

--- a/services/llm-api/Dockerfile
+++ b/services/llm-api/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM registry.menlo.ai/dockerhub/golang:${GO_VERSION} AS builder
+FROM golang:${GO_VERSION} AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -9,7 +9,7 @@ COPY . ./
 RUN go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -o /out/llm-api ./cmd/server
 
-FROM registry.menlo.ai/dockerhub/debian:bookworm-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \

--- a/services/mcp-tools/Dockerfile
+++ b/services/mcp-tools/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM registry.menlo.ai/dockerhub/golang:${GO_VERSION}-alpine AS builder
+FROM golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o mcp-tools .
 
 # Runtime stage
-FROM registry.menlo.ai/dockerhub/alpine:latest
+FROM alpine:latest
 
 RUN apk --no-cache add ca-certificates
 WORKDIR /app

--- a/services/media-api/Dockerfile
+++ b/services/media-api/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM registry.menlo.ai/dockerhub/golang:${GO_VERSION} as build
+FROM golang:${GO_VERSION} as build
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -8,7 +8,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/media-api ./cmd/server
 
-FROM registry.menlo.ai/dockerhub/debian:bookworm-slim
+FROM debian:bookworm-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*

--- a/services/memory-tools/Dockerfile
+++ b/services/memory-tools/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage
 ARG GO_VERSION=1.25
 
-FROM registry.menlo.ai/dockerhub/golang:${GO_VERSION}-alpine AS builder
+FROM golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /app
 # Install build dependencies
@@ -18,7 +18,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o memory-tools ./cmd/server
 
 # Final stage
-FROM registry.menlo.ai/dockerhub/alpine:latest
+FROM alpine:latest
 
 # Install runtime dependencies
 RUN apk --no-cache add ca-certificates curl

--- a/services/realtime-api/Dockerfile
+++ b/services/realtime-api/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM registry.menlo.ai/dockerhub/golang:${GO_VERSION} as build
+FROM golang:${GO_VERSION} as build
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -8,7 +8,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/realtime-api ./cmd/server
 
-FROM registry.menlo.ai/dockerhub/debian:bookworm-slim
+FROM debian:bookworm-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*

--- a/services/response-api/Dockerfile
+++ b/services/response-api/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.25
 
-FROM registry.menlo.ai/dockerhub/golang:${GO_VERSION} as build
+FROM golang:${GO_VERSION} as build
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -8,7 +8,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/response-api ./cmd/server
 
-FROM registry.menlo.ai/dockerhub/debian:bookworm-slim
+FROM debian:bookworm-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Describe Your Changes

This pull request updates all Dockerfiles across the project to stop using custom Menlo registry base images and instead use official upstream images for Node.js, Golang, Debian, Alpine, and Nginx. This change improves transparency, reduces reliance on private image registries, and simplifies image maintenance.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed