### PR TITLE
fix: search box highlight multiple conv

### DIFF
--- a/apps/web/src/components/search/search-dialog.tsx
+++ b/apps/web/src/components/search/search-dialog.tsx
@@ -177,7 +177,7 @@ export function SearchDialog({ open }: SearchDialogProps) {
             {recentSearches.map((conversation) => (
               <CommandItem
                 key={conversation.id}
-                value={conversation.title}
+                value={`${conversation.id}-${conversation.title}`}
                 onSelect={() => handleSelectConversation(conversation.id)}
                 className="cursor-pointer"
               >
@@ -194,7 +194,7 @@ export function SearchDialog({ open }: SearchDialogProps) {
             {searchResults.withProject.map(({ conversation, projectName }) => (
               <CommandItem
                 key={conversation.id}
-                value={`${conversation.title} ${projectName}`}
+                value={`${conversation.id}-${conversation.title} ${projectName}`}
                 onSelect={() => handleSelectConversation(conversation.id)}
                 className="cursor-pointer"
               >
@@ -216,7 +216,7 @@ export function SearchDialog({ open }: SearchDialogProps) {
             {searchResults.withoutProject.map((conversation) => (
               <CommandItem
                 key={conversation.id}
-                value={conversation.title}
+                value={`${conversation.id}-${conversation.title}`}
                 onSelect={() => handleSelectConversation(conversation.id)}
                 className="cursor-pointer"
               >


### PR DESCRIPTION
## Describe Your Changes

Updated the value prop for all CommandItem components to include the conversation ID prefix, This ensures each item has a unique value for the Command component's internal filtering logic

<img width="1348" height="970" alt="Screenshot 2026-01-02 at 14 04 05" src="https://github.com/user-attachments/assets/9235f691-1b10-47db-b4de-27104ce265ca" />

## Fixes Issues

- Closes #[JAN-159](https://linear.app/jan-ai/issue/JAN-159/search-box-highlight-multiple-convo)
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed