### PR TITLE
chore: change auth dev domain

### DIFF
--- a/.github/workflows/ci-app-web-dev.yml
+++ b/.github/workflows/ci-app-web-dev.yml
@@ -30,7 +30,7 @@ jobs:
         JAN_BASE_URL=https://api-dev.jan.ai/v1
         JAN_API_BASE_URL=https://api-dev.jan.ai/
         ENVIRONMENT=dev
-        VITE_AUTH_URL=https://auth-dev.jan.ai
+        VITE_AUTH_URL=https://auth-dev.menlo.ai
         VITE_AUTH_REALM=jan
         VITE_AUTH_CLIENT_ID=jan-client
         VITE_OAUTH_REDIRECT_URI=https://chat-dev.jan.ai/auth/callback

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -114,7 +114,7 @@ export default defineConfig(({ mode }) => {
       JAN_API_BASE_URL: JSON.stringify(env.JAN_API_BASE_URL),
       VITE_GA_ID: JSON.stringify(env.VITE_GA_ID),
       VITE_AUTH_URL: JSON.stringify(
-        env.VITE_AUTH_URL || "https://auth-dev.jan.ai",
+        env.VITE_AUTH_URL || "https://auth-dev.menlo.ai",
       ),
       VITE_AUTH_REALM: JSON.stringify(env.VITE_AUTH_REALM || "jan"),
       VITE_AUTH_CLIENT_ID: JSON.stringify(


### PR DESCRIPTION
This pull request updates the authentication URL for the development environment to use the new Menlo domain. This change ensures that both the CI workflow and the local development configuration point to the correct authentication service.

Authentication configuration updates:

* [`.github/workflows/ci-app-web-dev.yml`](diffhunk://#diff-bc9add1d98d278d5c3cd9e9e3b904faf3a9731eb269c40cd5c40f56859d2822cL33-R33): Changed the value of `VITE_AUTH_URL` from `https://auth-dev.jan.ai` to `https://auth-dev.menlo.ai` for the CI environment.
* [`apps/web/vite.config.ts`](diffhunk://#diff-eea049695b0188b525a44f51269fe670485ed3e355f8cede185cafedec24d786L117-R117): Updated the default value of `VITE_AUTH_URL` to `https://auth-dev.menlo.ai` for local development builds.