### PR TITLE
fix: private chat session

### DIFF
--- a/apps/web/src/stores/private-chat-store.ts
+++ b/apps/web/src/stores/private-chat-store.ts
@@ -16,7 +16,7 @@ export const usePrivateChat = create<PrivateChatState>()(
     }),
     {
       name: LOCAL_STORAGE_KEY.PRIVATE_CHAT,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => sessionStorage),
     },
   ),
 );


### PR DESCRIPTION
## Describe Your Changes

### Summary
Changed private chat setting storage from localStorage to sessionStorage to make it tab-specific instead of global
Changes
Modified `private-chat-store.ts` to use sessionStorage instead of localStorage

### Behavior
Before: Enabling private chat in one tab would enable it across all browser tabs (shared via localStorage)

After: Private chat is now isolated per browser tab. Each tab maintains its own independent private chat state via sessionStorage

## Fixes Issues

<img width="3024" height="1964" alt="Screenshot 2026-01-08 at 10 12 51" src="https://github.com/user-attachments/assets/0e2184d8-fdd7-48f0-94f4-bb85ea1e623e" />

- Closes #[JAN-226](https://linear.app/jan-ai/issue/JAN-226/private-chat-was-saved-even-if-i-open-a-new-tab)
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed