### PR TITLE
feat: codeblock user message

### DIFF
--- a/apps/web/src/components/threads/message-item.tsx
+++ b/apps/web/src/components/threads/message-item.tsx
@@ -131,13 +131,13 @@ export const MessageItem = memo(
           // --- Display math: \[...\] surrounded by newlines
           s = s.replace(
             /(^|\n)\\\[\s*\n([\s\S]*?)\n\s*\\\](?=\n|$)/g,
-            (_, pre, inner) => `${pre}$$\n${inner.trim()}\n$$`
+            (_, pre, inner) => `${pre}$$\n${inner.trim()}\n$$`,
           );
 
           // --- Inline math: space \( ... \)
           s = s.replace(
             /(^|[^$\\])\\\((.+?)\\\)(?=[^$\\]|$)/g,
-            (_, pre, inner) => `${pre}$${inner.trim()}$`
+            (_, pre, inner) => `${pre}$${inner.trim()}$`,
           );
 
           // --- Escape $<number> to prevent Markdown from treating it as LaTeX
@@ -158,6 +158,38 @@ export const MessageItem = memo(
       return result;
     };
 
+    // Render user text with code blocks only (no other markdown)
+    const renderUserTextWithCodeBlocks = (text: string) => {
+      const codeBlockRegex = /(```[\s\S]*?```)/g;
+      const parts = text.split(codeBlockRegex);
+
+      return parts.map((part, index) => {
+        // Check if this part is a code block
+        if (part.startsWith("```") && part.endsWith("```")) {
+          // Remove the triple backticks and optional language identifier
+          const codeContent = part
+            .replace(/^```[^\n]*\n?/, "") // Remove opening ``` and language
+            .replace(/\n?```$/, ""); // Remove closing ```
+
+          return (
+            <pre
+              key={index}
+              className="bg-muted rounded-md p-2 overflow-x-auto"
+            >
+              <code>{codeContent}</code>
+            </pre>
+          );
+        } else {
+          // Render plain text (preserve whitespace)
+          return part ? (
+            <span key={index} className="whitespace-pre-wrap">
+              {part}
+            </span>
+          ) : null;
+        }
+      });
+    };
+
     const renderTextPart = (part: { text: string }, partIndex: number) => {
       // Don't render if text is empty
       if (!part.text || part.text.trim() === "") {
@@ -172,17 +204,12 @@ export const MessageItem = memo(
           from={message.role}
           className={cn(
             "group",
-            isFirstMessage && message.role === MESSAGE_ROLE.USER && "mt-0!"
+            isFirstMessage && message.role === MESSAGE_ROLE.USER && "mt-0!",
           )}
         >
-          <MessageContent
-            className={cn(
-              "leading-relaxed",
-              message.role === MESSAGE_ROLE.USER && "whitespace-pre-wrap"
-            )}
-          >
+          <MessageContent className={cn("leading-relaxed")}>
             {message.role === MESSAGE_ROLE.USER ? (
-              part.text
+              renderUserTextWithCodeBlocks(part.text)
             ) : (
               <MessageResponse>{normalizeLatex(part.text)}</MessageResponse>
             )}
@@ -194,7 +221,7 @@ export const MessageItem = memo(
                 "gap-0 justify-end transition-opacity",
                 status === CHAT_STATUS.STREAMING
                   ? "opacity-0 pointer-events-none"
-                  : "opacity-0 group-hover:opacity-100"
+                  : "opacity-0 group-hover:opacity-100",
               )}
             >
               {onRegenerate && (
@@ -217,7 +244,7 @@ export const MessageItem = memo(
               className={cn(
                 "mt-1 gap-0 transition-opacity",
                 status === CHAT_STATUS.STREAMING &&
-                  "opacity-0 pointer-events-none"
+                  "opacity-0 pointer-events-none",
               )}
             >
               <MessageAction onClick={() => handleCopy(part.text)} label="Copy">
@@ -240,7 +267,7 @@ export const MessageItem = memo(
 
     const renderFilePart = (
       part: { filename?: string; url?: string; mediaType?: string },
-      partIndex: number
+      partIndex: number,
     ) => {
       const isAssistant = message.role === MESSAGE_ROLE.ASSISTANT;
       const isImage = part.mediaType?.startsWith("image/");
@@ -257,7 +284,7 @@ export const MessageItem = memo(
         >
           <MessageAttachments
             className={cn(
-              isAssistant && "ml-0 mr-auto" // Left-align for assistant
+              isAssistant && "ml-0 mr-auto", // Left-align for assistant
             )}
           >
             <MessageAttachment
@@ -265,7 +292,7 @@ export const MessageItem = memo(
               key={part.filename || "image"}
               className={cn(
                 isAssistant && "size-64", // Bigger for assistant (size-64 = 16rem = 256px vs size-24 = 6rem = 96px)
-                isImage && !isLoading && displayUrl && "cursor-pointer"
+                isImage && !isLoading && displayUrl && "cursor-pointer",
               )}
               onClick={() => {
                 if (isImage && displayUrl && !isLoading) {
@@ -288,7 +315,7 @@ export const MessageItem = memo(
                 className={cn(
                   "gap-0 transition-opacity",
                   status === CHAT_STATUS.STREAMING &&
-                    "opacity-0 pointer-events-none"
+                    "opacity-0 pointer-events-none",
                 )}
               >
                 <MessageAction
@@ -328,7 +355,7 @@ export const MessageItem = memo(
                 "w-full overflow-auto relative",
                 isStreaming
                   ? "max-h-32 opacity-70 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
-                  : "h-auto opacity-100"
+                  : "h-auto opacity-100",
               )}
             >
               <ReasoningContent>{part.text}</ReasoningContent>
@@ -475,7 +502,7 @@ export const MessageItem = memo(
       prevProps.isLastMessage === nextProps.isLastMessage &&
       prevProps.status === nextProps.status
     );
-  }
+  },
 );
 
 MessageItem.displayName = "MessageItem";


### PR DESCRIPTION
## Describe Your Changes

### Summary
Enable code block rendering for user messages while preserving plain text formatting for all other content.

### Changes
Added `renderUserTextWithCodeBlocks()` function to detect and render code blocks with triple backticks in user messages
User messages now display code blocks with proper formatting (background, padding, rounded corners) while keeping other text as plain (no markdown processing for bold, italic, links, etc.)
Code blocks automatically strip triple backticks and language identifiers before rendering
Assistant messages continue to use full markdown rendering via MessageResponse

## Fixes Issues

<img width="3024" height="1964" alt="Screenshot 2026-01-08 at 10 46 40" src="https://github.com/user-attachments/assets/680a0e62-6001-40a2-8999-810d2ca942a3" />
<img width="3024" height="1964" alt="Screenshot 2026-01-08 at 10 46 22" src="https://github.com/user-attachments/assets/8c0118eb-88b2-42fd-84a1-3c59e8c6a9ce" />


- Closes #[JAN-173](https://linear.app/jan-ai/issue/JAN-173/codeblock-from-user-message-is-not-formatted-as-from-assistant)
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed